### PR TITLE
reset the outline state when the doc is not shown

### DIFF
--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -141,6 +141,7 @@ function DocPage({ file, renderStackOffset = 0 }: IDocPageProps) {
       }
     }
     loadPreview();
+    return function(){ dispatch(setHeaders([])) }
   }, [file.id]);
 
   const handleDocContentClick = useCallback(


### PR DESCRIPTION
This was tested manually by clicking on a folder in the sidebar after displaying a document.