### PR TITLE
don't log response bodies in the console

### DIFF
--- a/packages/website/src/context/ExtInstallStatus.tsx
+++ b/packages/website/src/context/ExtInstallStatus.tsx
@@ -25,6 +25,7 @@ export function ExtInstallStatusProvider({ children }) {
         setValue({ isDetecting: false, installInfo: info ? info : undefined });
         console.log('Detect extension completed, info =', info);
       } catch (e) {
+        console.log('Detect extension failed');
         setValue({ isDetecting: false, isDetectFailed: true });
       }
     }

--- a/packages/website/src/hooks/useFileMeta.tsx
+++ b/packages/website/src/hooks/useFileMeta.tsx
@@ -32,7 +32,7 @@ export default function useFileMeta(id?: string) {
           fileId: id!,
           fields: '*',
         });
-        console.log('useFileMeta files.get', respFile);
+        console.debug('useFileMeta files.get', id);
 
         // If another request is performed, simply ignore this result.
         // This may happen when id changes very frequently

--- a/packages/website/src/hooks/useFolderFilesMeta.tsx
+++ b/packages/website/src/hooks/useFolderFilesMeta.tsx
@@ -38,7 +38,7 @@ export function useFolderFilesMeta(id?: string) {
             fields: '*',
             pageSize: 1000,
           });
-          console.log(`loadFolderFilesMetadata files.list (page #${i + 1})`, id, resp);
+          console.log(`loadFolderFilesMetadata files.list (page #${i + 1})`, id);
 
           if (reqRef.current !== checkpoint) {
             break;

--- a/packages/website/src/hooks/useLoadDriveFiles.tsx
+++ b/packages/website/src/hooks/useLoadDriveFiles.tsx
@@ -27,10 +27,9 @@ export default function useLoadDriveFiles() {
           q: `trashed = false and (mimeType = '${MimeTypes.GoogleFolder}')`,
           fields: getConfig().DEFAULT_FILE_FIELDS,
         });
-        console.log(
+        console.debug(
           `useLoadDriveFiles files.list (page #${i + 1})`,
           getConfig().REACT_APP_ROOT_DRIVE_ID,
-          resp
         );
         dispatch(updateFiles(resp.result.files ?? []));
         if (resp.result.nextPageToken) {

--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -101,12 +101,10 @@ function DocPage({ file, renderStackOffset = 0 }: IDocPageProps) {
   });
 
   function updateDoc(content: HTMLBodyElement | string) {
-    console.log("Update DOC");
     if (typeof content === "string"){
       setDocContent(content);
     } else {
       setDocContent(content.innerHTML);
-      console.log("Setting headers");
       dispatch(setHeaders(
         Array.from(content.querySelectorAll("h1, h2, h3, h4, h5, h6")).map(fromHTML)
       ));
@@ -123,7 +121,7 @@ function DocPage({ file, renderStackOffset = 0 }: IDocPageProps) {
           fileId: file.id!,
           mimeType: 'text/html',
         });
-        console.log('DocPage files.export', file.id, resp);
+        console.log('DocPage files.export', file.id);
 
         const parser = new DOMParser();
         const htmlDoc = parser.parseFromString(resp.body, 'text/html');


### PR DESCRIPTION
These take up a lot of space.
They can always be seen in the network tab.

Also
* remove and add a few logging statements
* use log levels.