### PR TITLE
Toggle revision history by clicking on last modified

### DIFF
--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -94,7 +94,6 @@ function externallyLinkHeaders(baseEl: HTMLElement, fileId: string) {
 function DocPage({ file, renderStackOffset = 0 }: IDocPageProps) {
   const [docContent, setDocContent] = useState('');
   const [isLoading, setIsLoading] = useState(true);
-  const revs: Array<gapi.client.drive.Revision> = []
   const history = useHistory();
   const dispatch = useDispatch();
 

--- a/packages/website/src/pages/ContentPage/FolderPage.tsx
+++ b/packages/website/src/pages/ContentPage/FolderPage.tsx
@@ -75,10 +75,12 @@ export interface IFolderPageProps {
   renderStackOffset?: number;
 }
 
+export const folderPageId = 'FolderPage';
+
 function FolderPage({ file, shortCutFile, renderStackOffset = 0 }: IFolderPageProps) {
   useManagedRenderStack({
     depth: renderStackOffset,
-    id: 'FolderPage',
+    id: folderPageId,
     file,
   });
 

--- a/packages/website/src/pages/FileAction.tsx
+++ b/packages/website/src/pages/FileAction.tsx
@@ -8,6 +8,7 @@ import {
 } from 'office-ui-fabric-react';
 import React, { useMemo } from 'react';
 import Avatar from 'react-avatar';
+import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { DriveIcon } from '../components';
 import { getConfig } from '../config';
@@ -21,11 +22,13 @@ import { showMoveFile } from './FileAction.moveFile';
 import { showRenameFile } from './FileAction.renameFile';
 import { showTrashFile } from './FileAction.trashFile';
 import responsiveStyle from '../layout/responsive.module.scss';
+import { toggleRevisions } from '../reduxSlices/files';
 
 function FileAction() {
   // Support we have a folder, containing a shortcut to a README document,
   // the rInner is README and the rOuter is the folder.
   const { inMost: rInner, outMost: rOuter } = useRender();
+  const dispatch = useDispatch();
 
   const history = useHistory();
 
@@ -40,6 +43,9 @@ function FileAction() {
       // For non-folder, show modify date, and how to open it.
       commands.push({
         key: 'modify_user',
+        onClick: () => {
+          dispatch(toggleRevisions());
+        },
         text: (
           <Stack
             verticalAlign="center"

--- a/packages/website/src/pages/FileAction.tsx
+++ b/packages/website/src/pages/FileAction.tsx
@@ -26,10 +26,9 @@ function FileAction() {
   // Support we have a folder, containing a shortcut to a README document,
   // the rInner is README and the rOuter is the folder.
   const { inMost: rInner, outMost: rOuter } = useRender();
-  let [revisionsEnabled, setRevisionsEnabled] = useState(false);
+  const [revisionsEnabled, setRevisionsEnabled] = useState("");
   function toggleRevisions() {
-    revisionsEnabled = !revisionsEnabled;
-    setRevisionsEnabled(revisionsEnabled);
+    setRevisionsEnabled(v => v === rInner?.file.id! ? "" : rInner?.file.id!);
   }
   const revs: Array<gapi.client.drive.Revision> = []
   const [revisions, setRevisions] = useState(revs);
@@ -239,11 +238,12 @@ function FileAction() {
   if (commandBarItems.length === 0 && commandBarOverflowItems.length === 0) {
     return null;
   }
+  const showRevisions = revisionsEnabled && (revisionsEnabled === rInner?.file.id) && (revisions.length > 0);
 
   return (
     <div>
       <CommandBar items={commandBarItems} overflowItems={commandBarOverflowItems} />
-      {revisionsEnabled && (
+      {showRevisions && (
         <div className="revisions">
           <hr/>
           {revisions.map((revision) => {

--- a/packages/website/src/pages/FileAction.tsx
+++ b/packages/website/src/pages/FileAction.tsx
@@ -21,6 +21,7 @@ import { showMoveFile } from './FileAction.moveFile';
 import { showRenameFile } from './FileAction.renameFile';
 import { showTrashFile } from './FileAction.trashFile';
 import responsiveStyle from '../layout/responsive.module.scss';
+import { folderPageId } from './ContentPage/FolderPage';
 
 function FileAction() {
   // Support we have a folder, containing a shortcut to a README document,
@@ -220,13 +221,14 @@ function FileAction() {
   }, [rInner?.file, rOuter?.file, outerFolder.file, history]);
 
   useEffect(() => {
+    if (rInner?.id === folderPageId) { return }
     const fields = "revisions(id, modifiedTime, lastModifyingUser, exportLinks)"
     async function loadRevisions() {
       try {
         const resp = await gapi.client.drive.revisions.list({fileId: rInner?.file.id!, fields})
         setRevisions(resp.result.revisions!.reverse());
       } catch(e) {
-        console.error('DocPage files.revisions', rInner?.file.id, e);
+        console.error('DocPage files.revisions', rInner, e);
       }
     }
 

--- a/packages/website/src/pages/FileAction.tsx
+++ b/packages/website/src/pages/FileAction.tsx
@@ -26,10 +26,10 @@ function FileAction() {
   // Support we have a folder, containing a shortcut to a README document,
   // the rInner is README and the rOuter is the folder.
   const { inMost: rInner, outMost: rOuter } = useRender();
-  const [revisionsEnabled, setRevisionsEnabled] = useState(false);
+  let [revisionsEnabled, setRevisionsEnabled] = useState(false);
   function toggleRevisions() {
-    console.info("toggling revisions");
-    setRevisionsEnabled(!revisionsEnabled)
+    revisionsEnabled = !revisionsEnabled;
+    setRevisionsEnabled(revisionsEnabled);
   }
   const revs: Array<gapi.client.drive.Revision> = []
   const [revisions, setRevisions] = useState(revs);
@@ -47,10 +47,7 @@ function FileAction() {
       // For non-folder, show modify date, and how to open it.
       commands.push({
         key: 'modify_user',
-        onClick: () => {
-          console.info("click toggle revisions");
-          toggleRevisions();
-        },
+        onClick: () => { toggleRevisions(); },
         text: (
           <Stack
             verticalAlign="center"
@@ -248,6 +245,7 @@ function FileAction() {
       <CommandBar items={commandBarItems} overflowItems={commandBarOverflowItems} />
       {revisionsEnabled && (
         <div className="revisions">
+          <hr/>
           {revisions.map((revision) => {
             const htmlLink = (revision.exportLinks ?? {})["text/html"];
             return (<Stack
@@ -272,7 +270,8 @@ function FileAction() {
             </Stack>
             )
           })
-        }
+          }
+          <hr/>
         </div>
       )}
     </div>

--- a/packages/website/src/pages/FileAction.tsx
+++ b/packages/website/src/pages/FileAction.tsx
@@ -252,21 +252,24 @@ function FileAction() {
               key={revision.id}
               verticalAlign="center"
               horizontal
-              tokens={{ childrenGap: 8 }}
+              tokens={{ childrenGap: 16, padding: 2 }}
               className={styles.note}
             >
               <a href={htmlLink}>
                 {dayjs(revision.modifiedTime).fromNow()}
               </a>
-              <Avatar
-                name={revision.lastModifyingUser?.displayName}
-                src={revision.lastModifyingUser?.photoLink}
-                size="20"
-                round
-              />
-              <span>
-                {revision.lastModifyingUser?.displayName}
-              </span>
+              <div>
+                <Avatar
+                  name={revision.lastModifyingUser?.displayName}
+                  src={revision.lastModifyingUser?.photoLink}
+                  size="20"
+                  round
+                />
+                <span>
+                  &nbsp;
+                  {revision.lastModifyingUser?.displayName}
+                </span>
+              </div>
             </Stack>
             )
           })

--- a/packages/website/src/reduxSlices/files.ts
+++ b/packages/website/src/reduxSlices/files.ts
@@ -6,12 +6,14 @@ export interface FilesState {
   isLoading: boolean;
   error: Error | undefined;
   mapIdToFile: Record<string, DriveFile>;
+  revisions: boolean;
 }
 
 const initialState: FilesState = {
   isLoading: true,
   error: undefined,
   mapIdToFile: {},
+  revisions: false,
 };
 
 export const slice = createSlice({
@@ -38,11 +40,19 @@ export const slice = createSlice({
     removeFile: (state, { payload }: { payload: string }) => {
       delete state.mapIdToFile[payload];
     },
+    toggleRevisions: (state) => {
+      state.revisions = !state.revisions
+    },
+    disableRevisions: (state) => {
+      state.revisions = false
+    },
   },
 });
 
 export const {
   setLoading,
+  toggleRevisions,
+  disableRevisions,
   setError,
   clearFileList,
   updateFile,
@@ -50,6 +60,7 @@ export const {
   removeFile,
 } = slice.actions;
 
+export const selectRevisions = (state: { files: FilesState }) => state.files.revisions;
 export const selectLoading = (state: { files: FilesState }) => state.files.isLoading;
 export const selectError = (state: { files: FilesState }) => state.files.error;
 export const selectMapIdToFile = (state: { files: FilesState }) => state.files.mapIdToFile;

--- a/packages/website/src/reduxSlices/files.ts
+++ b/packages/website/src/reduxSlices/files.ts
@@ -6,14 +6,12 @@ export interface FilesState {
   isLoading: boolean;
   error: Error | undefined;
   mapIdToFile: Record<string, DriveFile>;
-  revisions: boolean;
 }
 
 const initialState: FilesState = {
   isLoading: true,
   error: undefined,
   mapIdToFile: {},
-  revisions: false,
 };
 
 export const slice = createSlice({
@@ -40,19 +38,11 @@ export const slice = createSlice({
     removeFile: (state, { payload }: { payload: string }) => {
       delete state.mapIdToFile[payload];
     },
-    toggleRevisions: (state) => {
-      state.revisions = !state.revisions
-    },
-    disableRevisions: (state) => {
-      state.revisions = false
-    },
   },
 });
 
 export const {
   setLoading,
-  toggleRevisions,
-  disableRevisions,
   setError,
   clearFileList,
   updateFile,
@@ -60,7 +50,6 @@ export const {
   removeFile,
 } = slice.actions;
 
-export const selectRevisions = (state: { files: FilesState }) => state.files.revisions;
 export const selectLoading = (state: { files: FilesState }) => state.files.isLoading;
 export const selectError = (state: { files: FilesState }) => state.files.error;
 export const selectMapIdToFile = (state: { files: FilesState }) => state.files.mapIdToFile;


### PR DESCRIPTION
This is dissapointing since we only have metadata.
There is no way to link to a revision or show a diff.
The only thing that can be offered is an HTML download.

Doing a direct fetch of the HTML download runs into auth issues.
Perhaps there is a way to fix this, but I don't think it is very useful
to show old revisions without any diff.

There is an unofficial URL for getting a diff,
but it is a JSON output that needs rendering.
https://docs.google.com/document/d/{file.id}/showrevision?id={file.id}&end={rev.id}&start={rev.id}