### PR TITLE
Extension: warn when not in shared drive

### DIFF
--- a/packages/browser-extension/src/contentScript/docs.tsx
+++ b/packages/browser-extension/src/contentScript/docs.tsx
@@ -28,6 +28,7 @@ type ParentTree = {
 type FileInfo = {
   isOrphanAndOwner?: boolean;
   parentTree?: ParentTree;
+  privateOwners?: gapi.client.drive.User[];
 };
 
 function buildWikiUrl(drive: ManifestDrive, id: string) {
@@ -60,7 +61,10 @@ async function loadFileInfo(fileId: string, token: Token): Promise<FileInfo | un
     log.info(
       'File does not have a drive id, maybe the owner did not put it in the Wiki, skip listing parents'
     );
-    return {};
+    const orgOwners = file.owners?.filter((owner) => owner.emailAddress?.split("@")?.[1] === manifest?.data.gapiHostedDomain)
+    return {
+      privateOwners: orgOwners
+    };
   }
 
   let discoveredDrive: ManifestDrive | undefined;
@@ -243,6 +247,12 @@ function App(props: { id: string }) {
             <ChevronRight16 />
           </a>
         </div>
+      )}
+      {Boolean(fi && fi?.privateOwners?.length) && (
+        <span className={cx(styles.tag, styles.warning)}>
+          <WarningAltFilled16 style={{ marginRight: 6 }} />
+          Not in shared drive.
+        </span>
       )}
     </>
   );

--- a/packages/browser-extension/src/utils/gapi.ts
+++ b/packages/browser-extension/src/utils/gapi.ts
@@ -40,6 +40,20 @@ export class GapiClient {
     }
   }
 
+  async addComment(
+    fileId: string,
+    content: string,
+  ): Promise<null> {
+    try {
+      await this.client.post(`https://www.googleapis.com/drive/v3/files/${fileId}/comments?fields=*`, {
+          content,
+      });
+      return null;
+    } catch (e) {
+      throw new Error(`Failed to post user comment: ${e.message}`);
+    }
+  }
+
   async getDriveFile(
     fileId: string,
     params: {


### PR DESCRIPTION
This was tested by loading some documents that were not in a shared drive along with some that were.