### PR TITLE
use ?versions to deep-link to the versions page

### DIFF
--- a/packages/browser-extension/src/contentScript/docs.tsx
+++ b/packages/browser-extension/src/contentScript/docs.tsx
@@ -1,6 +1,6 @@
 import cx from 'classnames';
 import { debounce } from 'lodash-es';
-import { waitSelector } from '../utils/contentScript';
+import { waitFor, waitSelector, triggerMouseEvent } from '../utils/contentScript';
 import styles from './docs.module.scss';
 import { Token } from 'client-oauth2';
 import { GapiClient } from '../utils/gapi';
@@ -227,6 +227,29 @@ function App(props: { id: string }) {
 }
 
 export async function runDocs(id: string) {
+  // Add ?versions to the url params to deep-link to the versions page
+  var urlParams = new URLSearchParams(window.location.search);
+  if (urlParams.has('versions')) {
+    console.debug('wait to click on versions link');
+    const docsNotice = await waitFor(() => {
+      const docsNotice = document.getElementById('docs-notice');
+      if (!docsNotice || docsNotice.textContent === "" || docsNotice.getAttribute("aria-disabled") === "true") {
+        throw new Error("No docs notice");
+      }
+      return docsNotice
+    })
+    if (docsNotice) {
+      console.debug("found versions link, triggering click")
+      triggerMouseEvent(docsNotice, "mousedown", {})
+      setTimeout(function(){
+        console.log("mouseup")
+        triggerMouseEvent(docsNotice, "mouseup", {})
+      }, 100)
+    } else {
+      console.debug("no docs version link found")
+    }
+  }
+
   const elements = await waitSelector('.docs-title-outer');
   const containerElement = elements[0] as HTMLDivElement;
 

--- a/packages/browser-extension/src/utils/contentScript.ts
+++ b/packages/browser-extension/src/utils/contentScript.ts
@@ -1,18 +1,60 @@
 import { backOff } from 'exponential-backoff';
 
 export async function waitSelector(selector: string): Promise<NodeListOf<Element>> {
-  const el = await backOff(
-    async () => {
+  return waitFor(() => {
       const el = document.querySelectorAll(selector);
       if (el.length === 0) {
         throw new Error(`Wait selector ${selector} failed`);
       }
       return el;
+    }
+  )
+}
+
+export async function waitFor<T>(check: () => T): Promise<T> {
+  return await backOff(
+    async () => {
+      return check()
     },
     {
       maxDelay: 5000,
       startingDelay: 100,
     }
-  );
-  return el;
+  )
+}
+
+export function triggerMouseEvent(element: Element, eventName: string, userOptions: {[i:string]: any}) {
+  const options : {[i:string]: any} = { // defaults
+    clientX: 0, clientY: 0, button: 0,
+    ctrlKey: false, altKey: false, shiftKey: false,
+    metaKey: false, bubbles: true, cancelable: true
+     // create event object:
+  }
+  const event = element.ownerDocument.createEvent("MouseEvents");
+
+  if (!/^(?:click|mouse(?:down|up|over|move|out))$/.test(eventName)) {
+    throw new Error("Only MouseEvents supported");
+  }
+
+  if (typeof userOptions != 'undefined'){ // set the userOptions
+    for (var prop in userOptions) {
+      if (userOptions.hasOwnProperty(prop))
+        options[prop] = userOptions[prop];
+    }
+  }
+  const view = element.ownerDocument.defaultView
+  if (!view) {
+    console.debug("element.ownerDocument.defaultView is null")
+    return
+  }
+
+  // initialize the event object
+  event.initMouseEvent(eventName, options.bubbles, options.cancelable,
+                       view,  options.button,
+                       options.clientX, options.clientY, options.clientX,
+                       options.clientY, options.ctrlKey, options.altKey,
+                       options.shiftKey, options.metaKey, options.button,
+                       element);
+  // dispatch!
+  element.dispatchEvent(event);
 }


### PR DESCRIPTION
I would like to link to specific revisions, but it doesn't seem there is an id to link to and that it would instead have to parse date text relative to the current time and match that.