### PR TITLE
fix headers with comment links

### DIFF
--- a/packages/website/src/layout/Sider.tsx
+++ b/packages/website/src/layout/Sider.tsx
@@ -7,13 +7,13 @@ import React, { useCallback, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { DriveIcon } from '../components';
 import { getConfig } from '../config';
+import { selectHeaders } from '../reduxSlices/doc';
 import {
   selectError,
   selectLoading,
   selectMapIdToChildren,
   selectMapIdToFile,
 } from '../reduxSlices/files';
-import { selectHeaders } from '../reduxSlices/doc';
 import {
   activate,
   expand,
@@ -30,7 +30,7 @@ import {
   MimeTypes,
   parseFolderChildrenDisplaySettings,
 } from '../utils';
-import { DocHeader, TreeHeading, isTreeHeading, MakeTree } from '../utils/docHeaders';
+import { DocHeader, TreeHeading, isTreeHeading } from '../utils/docHeaders';
 import styles from './Sider.module.scss';
 import { HeaderExtraActionsForMobile } from '.';
 
@@ -210,7 +210,7 @@ function Sider_({ isExpanded = true }: { isExpanded?: boolean }) {
   function toTreeElements(node: TreeHeading | DocHeader): JSX.Element {
     return isTreeHeading(node) ? treeNode(node, node.entries.map(toTreeElements)) : entryNode(node);
   }
-  const headerTreeNodes = MakeTree(headers.slice()).map(toTreeElements);
+  const headerTreeNodes = (headers ?? []).slice().map(toTreeElements);
 
   return (
     <div className={cx(styles.sider, { [styles.isExpanded]: isExpanded })}>

--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -301,7 +301,11 @@ function DocPage({ file, renderStackOffset = 0 }: IDocPageProps) {
           parent.removeChild(child);
         }
         ReactDOM.render(
-          ReactComment({ comment, topHref: commentLink.getAttribute('href') ?? '#' }),
+          ReactComment({
+            comment,
+            htmlId: commentLink.id,
+            topHref: commentLink.getAttribute('href') ?? '#',
+          }),
           parent
         );
         // need to delete all the replies
@@ -319,12 +323,18 @@ function DocPage({ file, renderStackOffset = 0 }: IDocPageProps) {
     }
   }, [docComments, isLoading]);
 
-  function ReactComment(props: { topHref: string; comment: gapi.client.drive.Comment }) {
-    const { topHref, comment } = props;
+  function ReactComment(props: {
+    htmlId: string;
+    topHref: string;
+    comment: gapi.client.drive.Comment;
+  }) {
+    const { htmlId, topHref, comment } = props;
     return (
       <>
         <Stack horizontal key={topHref} tokens={{ childrenGap: 0, padding: 0 }}>
-          <a href={topHref}>↑</a>
+          <a id={htmlId} href={topHref}>
+            ↑
+          </a>
         </Stack>
         <Stack horizontal key={comment.id} tokens={{ childrenGap: 8, padding: 8 }}>
           <Stack>

--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -369,7 +369,7 @@ function DocPage({ file, renderStackOffset = 0 }: IDocPageProps) {
               <Stack>
                 <Avatar
                   name={reply.author?.displayName}
-                  src={reply.author?.photoLink}
+                  src={'https://' + reply.author?.photoLink}
                   size="30"
                   round
                 />

--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -89,6 +89,11 @@ function highlightAndLinkComments(baseEl: HTMLElement) {
     if (supLink.id.startsWith('cmnt_')) {
       const span = sup.previousElementSibling;
       if (!span || span.nodeName !== 'SPAN') {
+        if (span && span.id.startsWith('cmnt_')) {
+          // There are multiple sups next to eachother for replies
+          // This removes the replies
+          sup.remove();
+        }
         continue;
       }
 
@@ -116,6 +121,8 @@ function highlightAndLinkComments(baseEl: HTMLElement) {
       }
       link.setAttribute('style', style);
       link.textContent = span.textContent;
+      link.id = supLink.id;
+      sup.remove();
       span.replaceWith(link);
     }
   }

--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -1,3 +1,4 @@
+import { ArrowUp16, Launch16 } from '@carbon/icons-react';
 import { InlineLoading } from 'carbon-components-react';
 import { Stack } from 'office-ui-fabric-react';
 import React, { useCallback, useEffect, useState } from 'react';
@@ -321,52 +322,61 @@ function DocPage({ file, renderStackOffset = 0 }: IDocPageProps) {
         console.debug('did not find comment for', origText);
       }
     }
-  }, [docComments, isLoading]);
 
-  function ReactComment(props: {
-    htmlId: string;
-    topHref: string;
-    comment: gapi.client.drive.Comment;
-  }) {
-    const { htmlId, topHref, comment } = props;
-    return (
-      <>
-        <Stack horizontal key={topHref} tokens={{ childrenGap: 0, padding: 0 }}>
-          <a id={htmlId} href={topHref}>
-            ↑
-          </a>
-        </Stack>
-        <Stack horizontal key={comment.id} tokens={{ childrenGap: 8, padding: 8 }}>
-          <Stack>
-            <Avatar
-              name={comment.author?.displayName}
-              src={'https://' + comment.author?.photoLink}
-              size="30"
-              round
-            />
+    function ReactComment(props: {
+      htmlId: string;
+      topHref: string;
+      comment: gapi.client.drive.Comment;
+    }) {
+      const { htmlId, topHref, comment } = props;
+      return (
+        <>
+          <Stack horizontal key={topHref} tokens={{ childrenGap: 10, padding: 0 }}>
+            <a id={htmlId} href={topHref}>
+              Back
+              <ArrowUp16 />
+            </a>
+            <a
+              target="_blank"
+              rel="noreferrer"
+              href={'https://docs.google.com/document/d/' + file.id + '/?disco=' + comment.id}
+            >
+              View in Doc
+              <Launch16 />
+            </a>
           </Stack>
-          <Stack>
-            <p dangerouslySetInnerHTML={{ __html: comment.htmlContent ?? '' }}></p>
-          </Stack>
-        </Stack>
-        {comment.replies?.map((reply) => (
-          <Stack horizontal key={reply.id} tokens={{ childrenGap: 8, padding: 8 }}>
+          <Stack horizontal key={comment.id} tokens={{ childrenGap: 8, padding: 8 }}>
             <Stack>
               <Avatar
-                name={reply.author?.displayName}
-                src={reply.author?.photoLink}
+                name={comment.author?.displayName}
+                src={'https://' + comment.author?.photoLink}
                 size="30"
                 round
               />
             </Stack>
             <Stack>
-              <p dangerouslySetInnerHTML={{ __html: reply.htmlContent ?? '' }}></p>
+              <p dangerouslySetInnerHTML={{ __html: comment.htmlContent ?? '' }}></p>
             </Stack>
           </Stack>
-        ))}
-      </>
-    );
-  }
+          {comment.replies?.map((reply) => (
+            <Stack horizontal key={reply.id} tokens={{ childrenGap: 8, padding: 8 }}>
+              <Stack>
+                <Avatar
+                  name={reply.author?.displayName}
+                  src={reply.author?.photoLink}
+                  size="30"
+                  round
+                />
+              </Stack>
+              <Stack>
+                <p dangerouslySetInnerHTML={{ __html: reply.htmlContent ?? '' }}></p>
+              </Stack>
+            </Stack>
+          ))}
+        </>
+      );
+    }
+  }, [docComments, isLoading, file.id]);
 
   const handleDocContentClick = useCallback(
     (ev: React.MouseEvent) => {

--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -331,20 +331,26 @@ function DocPage({ file, renderStackOffset = 0 }: IDocPageProps) {
       const { htmlId, topHref, comment } = props;
       return (
         <>
-          <Stack horizontal key={topHref} tokens={{ childrenGap: 10, padding: 0 }}>
-            <a id={htmlId} href={topHref}>
-              Back
+          <Stack
+            horizontal
+            style={{ paddingLeft: '10px', paddingTop: '5px' }}
+            key={topHref}
+            tokens={{ childrenGap: 12, padding: 0 }}
+          >
+            <a id={htmlId} href={topHref} title="back to doc">
               <ArrowUp16 />
             </a>
             <a
               target="_blank"
               rel="noreferrer"
+              title="open in doc"
               href={'https://docs.google.com/document/d/' + file.id + '/?disco=' + comment.id}
             >
-              View in Doc
               <Launch16 />
             </a>
+            <em>{comment.quotedFileContent?.value}</em>
           </Stack>
+          <hr/>
           <Stack horizontal key={comment.id} tokens={{ childrenGap: 8, padding: 8 }}>
             <Stack>
               <Avatar

--- a/packages/website/src/reduxSlices/doc.ts
+++ b/packages/website/src/reduxSlices/doc.ts
@@ -1,8 +1,8 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { DocHeader } from '../utils/docHeaders';
+import { DocHeader, TreeHeading } from '../utils/docHeaders';
 
 export interface DocState {
-  headers: any[];
+  headers?: (TreeHeading | DocHeader)[];
   comments: gapi.client.drive.Comment[];
 }
 
@@ -15,7 +15,7 @@ export const slice = createSlice({
   name: 'doc',
   initialState: initialStateDoc,
   reducers: {
-    setHeaders: (state, { payload }: { payload: DocHeader[] }) => {
+    setHeaders: (state, { payload }: { payload: (TreeHeading | DocHeader)[] }) => {
       state.headers = payload;
     },
     setComments: (state, { payload }: { payload: gapi.client.drive.Comment[] }) => {

--- a/packages/website/src/utils/docHeaders.ts
+++ b/packages/website/src/utils/docHeaders.ts
@@ -11,8 +11,22 @@ export type DocHeader = DocLink & DocHeading;
 
 export function fromHTML(heading: Element): DocHeader {
   const level = parseInt(heading.nodeName.match(/\d/)?.[0] ?? '0');
+  let alteredText = '';
+  let needsAlteration = false;
+  // remove comment
+  for (const node of heading.children) {
+    if (node.nodeName === 'SUP') {
+      const supLink = node.children?.[0];
+      if (supLink.id.startsWith('cmnt_')) {
+        needsAlteration = true;
+        continue;
+      }
+    }
+    alteredText = alteredText + node.textContent ?? '';
+  }
+
   return {
-    text: heading.textContent ?? '',
+    text: needsAlteration ? alteredText : heading.textContent ?? '',
     id: heading.id,
     level,
   };

--- a/packages/website/src/utils/icons.tsx
+++ b/packages/website/src/utils/icons.tsx
@@ -1,5 +1,6 @@
 import {
   Add16,
+  ArrowUp16,
   ChevronDown16,
   ChevronRight16,
   Edit16,
@@ -20,6 +21,7 @@ import React from 'react';
 export function registerIcons() {
   register({
     icons: {
+      ArrowUp: <ArrowUp16 />,
       More: <OverflowMenuHorizontal16 />,
       ChevronRight: <ChevronRight16 />,
       ChevronDown: <ChevronDown16 />,


### PR DESCRIPTION
* don't show the superscript in the left sidebar
* when the header is already linked due to a comment,
don't externally link it.

Added on a couple commits for comment links and one to show the quoted text. All these commits can be viewed individually.