### PR TITLE
wikilink: show an icon

### DIFF
--- a/packages/browser-extension/src/contentScript/docs.module.scss
+++ b/packages/browser-extension/src/contentScript/docs.module.scss
@@ -56,6 +56,12 @@
   align-items: center;
 }
 
+.wikiTreeIcon {
+  & {
+    padding-top: 4px;
+  }
+}
+
 .wikiTreeItem {
   & {
     font-size: 1rem;

--- a/packages/browser-extension/src/contentScript/docs.tsx
+++ b/packages/browser-extension/src/contentScript/docs.tsx
@@ -228,7 +228,7 @@ function App(props: { id: string }) {
                 <a href={pi.url} target="_blank" rel="noreferrer" className={styles.wikiTreeItem}>
                   {pi.name}
                 </a>
-                <span>
+                <span className={styles.wikiTreeIcon}>
                   <ChevronRight16 />
                 </span>
               </>
@@ -239,8 +239,9 @@ function App(props: { id: string }) {
               {fi?.parentTree!.folder.name}
             </a>
           )}
-          <a href={fi!.parentTree!.file.url} target="_blank" rel="noreferrer" className={styles.wikiTreeItem}>
+          <a href={fi!.parentTree!.file.url} target="_blank" rel="noreferrer" className={styles.wikiTreeIcon}>
             <ChevronRight16 />
+            <Launch16/>
           </a>
         </div>
       )}


### PR DESCRIPTION
Also push the icons down a little bit.

The link was added previously but was essentially hidden.
Now there is a noticeable but hopefully not too intrusive icon.