### PR TITLE
in GDocs (browser ext) add the document name to the url parameters

### DIFF
--- a/packages/browser-extension/src/contentScript/docs.tsx
+++ b/packages/browser-extension/src/contentScript/docs.tsx
@@ -47,6 +47,20 @@ async function loadFileInfo(fileId: string, token: Token): Promise<FileInfo | un
     fields: '*',
     supportsAllDrives: true,
   });
+
+  // Put the document name in the URL
+  // Then when we send the link to others they will see the title
+  try {
+    var urlParams = new URLSearchParams(window.location.search);
+    if (file.name && !urlParams.get('n')) {
+      urlParams.set('n', file.name.replaceAll(' ', '_'));
+      const newUrl = window.location.origin + window.location.pathname + '?' + urlParams.toString();
+      window.history.replaceState({path: newUrl}, "", newUrl);
+    }
+  } catch (e) {
+    console.warn("error trying to add doc name to parameters ", e);
+  }
+
   log.info('File metadata', file);
   if (file.trashed) {
     log.info('Skipped the file since it is trashed');
@@ -296,7 +310,7 @@ function App(props: { id: string }) {
 }
 
 export async function runDocs(id: string) {
-  // Add ?versions to the url params to deep-link to the versions page
+  // Users can add ?versions to the url params to deep-link to the versions page
   var urlParams = new URLSearchParams(window.location.search);
   if (urlParams.has('versions')) {
     console.debug('wait to click on versions link');


### PR DESCRIPTION
Then when the link is shared by copying from the browser url
the title will be in the shared link.
The viewer of the link will know what the document is about
even if there is no link preview.