### PR TITLE
optimistically call the gdoc export API

### DIFF
--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -250,6 +250,14 @@ function DocPage({ file, renderStackOffset = 0 }: IDocPageProps) {
   }, [file.id, dispatch, setDocWithPlainText, setDocWithRichContent]);
 
   useEffect(() => {
+    // When optimistically rendering the document, only an id is available.
+    // Avoid optimistically fetching comments as well.
+    // This API call would actually succeed against a folder
+    // but we wouldn't end up using the resulit.
+    if (!file.name) {
+      return;
+    }
+
     async function loadComments() {
       try {
         // problem: this does not return all of the visible comments
@@ -269,7 +277,7 @@ function DocPage({ file, renderStackOffset = 0 }: IDocPageProps) {
     return function () {
       dispatch(setComments([]));
     };
-  }, [file.id]);
+  }, [file.id, dispatch, file.name]);
 
   useEffect(() => {
     const comments = docComments.filter((comment) => comment.resolved !== true);

--- a/packages/website/src/pages/ContentPage/FolderPage.tsx
+++ b/packages/website/src/pages/ContentPage/FolderPage.tsx
@@ -105,7 +105,9 @@ function FolderPage({ file, shortCutFile, renderStackOffset = 0 }: IFolderPagePr
   return (
     <div>
       {loading && <InlineLoading description="Loading folder contents..." />}
-      {readMeFile && <ContentPage file={readMeFile} renderStackOffset={renderStackOffset + 1} />}
+      {readMeFile && (
+        <ContentPage loading={null} file={readMeFile} renderStackOffset={renderStackOffset + 1} />
+      )}
       {!loading && !!error && error}
       {!loading && !error && (
         <div style={{ marginTop: 32 }}>

--- a/packages/website/src/pages/ContentPage/ShortcutPage.tsx
+++ b/packages/website/src/pages/ContentPage/ShortcutPage.tsx
@@ -24,6 +24,7 @@ function ShortcutPage({ file, renderStackOffset = 0 }: IShortcutPageProps) {
       {!loading && !!error && error}
       {!loading && !!pointingFile && (
         <ContentPage
+          loading={null}
           file={pointingFile}
           shortCutFile={file}
           renderStackOffset={renderStackOffset + 1}

--- a/packages/website/src/pages/ContentPage/index.tsx
+++ b/packages/website/src/pages/ContentPage/index.tsx
@@ -6,12 +6,19 @@ import PreviewPage from './PreviewPage';
 import ShortcutPage from './ShortcutPage';
 
 export interface IContentPageProps {
-  file: DriveFile;
+  loading: string | null;
+  file?: DriveFile;
   shortCutFile?: DriveFile;
   renderStackOffset?: number;
 }
 
-function ContentPage({ file, shortCutFile, renderStackOffset = 0 }: IContentPageProps) {
+function ContentPage({ loading, file, shortCutFile, renderStackOffset = 0 }: IContentPageProps) {
+  // Assume a document for speed in that case.
+  // We might be wrong, but that will get corrected without issue.
+  if (loading !== null) {
+    return <DocPage file={{ id: loading }} renderStackOffset={renderStackOffset} />;
+  }
+
   if (PreviewableMimeTypes.indexOf(file?.mimeType ?? '') > -1) {
     return <PreviewPage file={file!} renderStackOffset={renderStackOffset} />;
   }
@@ -37,7 +44,7 @@ function ContentPage({ file, shortCutFile, renderStackOffset = 0 }: IContentPage
   return (
     <div>
       This file cannot be previewed.{' '}
-      <a href={file.webViewLink} target="_blank" rel="noreferrer">
+      <a href={file!.webViewLink} target="_blank" rel="noreferrer">
         View in Google Drive
       </a>
     </div>

--- a/packages/website/src/pages/Page.tsx
+++ b/packages/website/src/pages/Page.tsx
@@ -54,7 +54,7 @@ function Page() {
       </div>
       {loading && <InlineLoading description="Loading file metadata..." />}
       {!loading && !!error && error}
-      {!loading && !!file && <ContentPage file={file} />}
+      {<ContentPage loading={loading || error ? id : null} file={file} />}
     </RightContainer>
   );
 }


### PR DESCRIPTION
If we are viewing a document this will load it before
waiting for the API call to fetch the full document details.
If not viewing a document, the API call will fail.
but that will not cause a problem.

I also don't notice any rendering glitches from this change