### PR TITLE
doc view: thumbnail preview of gdoc links

### DIFF
--- a/packages/website/src/components/DriveIcon.tsx
+++ b/packages/website/src/components/DriveIcon.tsx
@@ -1,5 +1,4 @@
 import { Launch16 } from '@carbon/icons-react';
-import React from 'react';
 import { DriveFile, mdLink, MimeTypes } from '../utils';
 
 export function DriveIcon({ file }: { file?: DriveFile }) {
@@ -22,6 +21,6 @@ export function DriveIcon({ file }: { file?: DriveFile }) {
   return <img src={src} width={16} alt="File Icon" />;
 }
 
-DriveIcon.getIconSrc = (mimeType, size = 32) => {
+DriveIcon.getIconSrc = (mimeType: string, size = 32) => {
   return `https://drive-thirdparty.googleusercontent.com/${size}/type/${mimeType}`;
 };

--- a/packages/website/src/pages/ContentPage/FolderPage.module.scss
+++ b/packages/website/src/pages/ContentPage/FolderPage.module.scss
@@ -28,3 +28,15 @@
     list-style: circle;
   }
 }
+
+.gdocLink {
+  .gdocThumbnail {
+    z-index: 0;
+    display: none;
+  }
+}
+.gdocLink:hover .gdocThumbnail {
+  z-index: 9999;
+  display: inline;
+  position: absolute;
+}


### PR DESCRIPTION
In Google Docs clicking on a doc link shows a thumbnail preview.
For this PR gdocwiki will show a thumbnail preview on hover. To do onclick we would need to change all links to popup a preview on click.

Google Docs also has a special way that doc links can be shown where there is a grey background and an icon to the left. Unfortunately that is lost in the html export and I don't see a way to recover that information.