### PR TITLE
with README and no sidebar list files with accordion

### DIFF
--- a/packages/website/src/App.tsx
+++ b/packages/website/src/App.tsx
@@ -30,10 +30,14 @@ import { SearchResult, SearchTag } from './pages/Search';
 import SearchAllTags from './pages/Search/AllTags';
 import Settings from './pages/Settings';
 import { selectMapIdToFile } from './reduxSlices/files';
-import { collapseAll, expand } from './reduxSlices/siderTree';
+import {
+  collapseAll,
+  expand,
+  selectSidebarOpen,
+  closeSidebar,
+  openSidebar,
+} from './reduxSlices/siderTree';
 import { history } from './utils';
-
-const expandSidebarByDefault = window.innerWidth >= 600;
 
 function DriveFilesLoader({ children }) {
   useLoadDriveFiles();
@@ -63,11 +67,11 @@ function useExtensionBannerController() {
 function App() {
   const dispatch = useDispatch();
   const { gapiLoaded } = useGapi();
-  const [isExpanded, setIsExpanded] = useState(expandSidebarByDefault);
+  const sidebarOpen = useSelector(selectSidebarOpen);
   const mapIdToFile = useSelector(selectMapIdToFile);
 
-  const handleOpenTOC = useCallback(() => setIsExpanded(true), []);
-  const handleCloseTOC = useCallback(() => setIsExpanded(false), []);
+  const handleOpenTOC = () => dispatch(openSidebar());
+  const handleCloseTOC = () => dispatch(closeSidebar());
   const handleTreeExpand = useCallback(() => {
     let ids: string[] = [];
     for (let id in mapIdToFile) {
@@ -89,12 +93,12 @@ function App() {
       <Router history={history}>
         <DriveFilesLoader>
           <Header aria-label="global actions">
-            {!isExpanded && (
+            {!sidebarOpen && (
               <HeaderGlobalAction key="open" aria-label="Open TOC" onClick={handleOpenTOC}>
                 <Menu20 />
               </HeaderGlobalAction>
             )}
-            {isExpanded && [
+            {sidebarOpen && [
               <HeaderGlobalAction key="close" aria-label="Close TOC" onClick={handleCloseTOC}>
                 <Close20 />
               </HeaderGlobalAction>,
@@ -134,9 +138,9 @@ function App() {
                 </div>
               </Trigger>
             </HeaderGlobalBar>
-            <Sider isExpanded={isExpanded} />
+            <Sider isExpanded={sidebarOpen} />
           </Header>
-          <Content isExpanded={isExpanded}>
+          <Content isExpanded={sidebarOpen}>
             <RenderStackProvider>
               <Switch>
                 <Route exact path="/">

--- a/packages/website/src/pages/ContentPage/FolderPage.tsx
+++ b/packages/website/src/pages/ContentPage/FolderPage.tsx
@@ -7,6 +7,7 @@ import { DriveFileName, DriveIcon, FileListTable } from '../../components';
 import { useManagedRenderStack } from '../../context/RenderStack';
 import { useFolderFilesMeta } from '../../hooks/useFolderFilesMeta';
 import { selectMapIdToFile } from '../../reduxSlices/files';
+import { selectSidebarOpen } from '../../reduxSlices/siderTree';
 import { DriveFile, mdLink, parseFolderChildrenDisplaySettings } from '../../utils';
 import styles from './FolderPage.module.scss';
 import ContentPage from '.';
@@ -60,7 +61,7 @@ function FolderChildrenList({ files, openInNewWindow }: IFolderChildrenProps) {
 function FolderChildrenHide({ files, openInNewWindow }: IFolderChildrenProps) {
   return (
     <Accordion align="start">
-      <AccordionItem title={`Sub pages (${files?.length ?? 0})`}>
+      <AccordionItem title={`Folder Contents (${files?.length ?? 0})`}>
         <FolderChildrenList files={files} openInNewWindow={openInNewWindow} />
       </AccordionItem>
     </Accordion>
@@ -82,6 +83,7 @@ function FolderPage({ file, shortCutFile, renderStackOffset = 0 }: IFolderPagePr
     file,
   });
 
+  const sidebarOpen = useSelector(selectSidebarOpen);
   const mapIdToFile = useSelector(selectMapIdToFile);
   const openInNewWindow = useMemo(() => {
     // If current folder is not in the tree, open new window
@@ -102,12 +104,23 @@ function FolderPage({ file, shortCutFile, renderStackOffset = 0 }: IFolderPagePr
     }
   }, [files]);
 
+  if (readMeFile) {
+    return (
+      <>
+        {!sidebarOpen && !loading && !error && (
+          <div style={{ maxWidth: '50rem' }}>
+            {loading && <InlineLoading description="Loading folder contents..." />}
+            <FolderChildrenHide openInNewWindow={openInNewWindow} files={files} />
+          </div>
+        )}
+        <ContentPage loading={null} file={readMeFile} renderStackOffset={renderStackOffset + 1} />
+      </>
+    );
+  }
+
   return (
     <div>
       {loading && <InlineLoading description="Loading folder contents..." />}
-      {readMeFile && (
-        <ContentPage loading={null} file={readMeFile} renderStackOffset={renderStackOffset + 1} />
-      )}
       {!loading && !!error && error}
       {!loading && !error && (
         <div style={{ marginTop: 32 }}>

--- a/packages/website/src/reduxSlices/siderTree.ts
+++ b/packages/website/src/reduxSlices/siderTree.ts
@@ -2,12 +2,14 @@ import { createSlice } from '@reduxjs/toolkit';
 import { DriveFile } from '../utils';
 
 export interface TreeState {
+  sidebarOpen: boolean;
   activeId?: string;
   expanded: Array<string>;
   selected: Array<string>;
 }
 
 const initialState: TreeState = {
+  sidebarOpen: window.innerWidth >= 600,
   expanded: [],
   selected: [],
 };
@@ -21,6 +23,14 @@ export const slice = createSlice({
   name: 'tree',
   initialState,
   reducers: {
+    closeSidebar: (state, { payload }: { payload: undefined }) => {
+      state.sidebarOpen = false;
+    },
+
+    openSidebar: (state, { payload }: { payload: undefined }) => {
+      state.sidebarOpen = true;
+    },
+
     setActiveId: (state, { payload }: { payload: string }) => {
       state.activeId = payload;
     },
@@ -75,7 +85,15 @@ export const slice = createSlice({
   },
 });
 
-export const { setActiveId, activate, expand, collapse, collapseAll } = slice.actions;
+export const {
+  closeSidebar,
+  openSidebar,
+  setActiveId,
+  activate,
+  expand,
+  collapse,
+  collapseAll,
+} = slice.actions;
 
 export const selectExpanded = (state: { tree: TreeState }) =>
   new Set(state.tree.expanded) as ReadonlySet<string>;
@@ -83,6 +101,8 @@ export const selectExpanded = (state: { tree: TreeState }) =>
 export const selectActiveId = (state: { tree: TreeState }) => state.tree.activeId;
 
 export const selectSelected = (state: { tree: TreeState }) => [...state.tree.selected];
+
+export const selectSidebarOpen = (state: { tree: TreeState }) => state.tree.sidebarOpen;
 
 export default slice.reducer;
 


### PR DESCRIPTION
Using the expandable accodion allows us to show folder content at the top of the page.
Previously they would be shown below the README content.

If the sidebar is showing, don't bother with the accordion
since the files are already listed in the sidebar.