### PR TITLE
don't display fileactions in edit doc mode with no sidebar

### DIFF
--- a/packages/website/src/pages/ContentPage/PreviewPage.tsx
+++ b/packages/website/src/pages/ContentPage/PreviewPage.tsx
@@ -1,7 +1,9 @@
 import { useEventListener } from 'ahooks';
 import { InlineLoading } from 'carbon-components-react';
 import React, { CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { useManagedRenderStack } from '../../context/RenderStack';
+import { selectSidebarOpen } from '../../reduxSlices/siderTree';
 import { DriveFile, HalfViewPreviewMimeTypes } from '../../utils';
 
 export interface IPreviewPageProps {
@@ -13,6 +15,7 @@ export interface IPreviewPageProps {
 function PreviewPage({ file, edit = false, renderStackOffset = 0 }: IPreviewPageProps) {
   const [isLoading, setIsLoading] = useState(true);
   const ref = useRef<HTMLIFrameElement>(null);
+  const sidebarOpen = useSelector(selectSidebarOpen);
 
   useManagedRenderStack({
     depth: renderStackOffset,
@@ -55,6 +58,8 @@ function PreviewPage({ file, edit = false, renderStackOffset = 0 }: IPreviewPage
     edit === true ? '/edit' : '/preview'
   );
 
+  const headSubtract = edit === true ? (!sidebarOpen ? 70 : 100) : 120;
+
   return (
     <div style={contentStyle}>
       <div>
@@ -64,7 +69,7 @@ function PreviewPage({ file, edit = false, renderStackOffset = 0 }: IPreviewPage
           width="100%"
           src={iframeSrc}
           ref={ref}
-          style={{ height: 'calc(100vh - 120px)', minHeight: 500 }}
+          style={{ height: `calc(100vh - ${headSubtract}px)`, minHeight: 500 }}
         />
       </div>
     </div>

--- a/packages/website/src/pages/ContentPage/PreviewPage.tsx
+++ b/packages/website/src/pages/ContentPage/PreviewPage.tsx
@@ -71,6 +71,7 @@ function PreviewPage({ file, edit = false, renderStackOffset = 0 }: IPreviewPage
         <iframe
           title="Preview"
           width="100%"
+          key={iframeSrc} // force the iframe to be recreated
           src={iframeSrc}
           ref={ref}
           style={{ height: `calc(100vh - ${headSubtract}px)`, minHeight: 500 }}

--- a/packages/website/src/pages/ContentPage/PreviewPage.tsx
+++ b/packages/website/src/pages/ContentPage/PreviewPage.tsx
@@ -53,12 +53,16 @@ function PreviewPage({ file, edit = false, renderStackOffset = 0 }: IPreviewPage
     );
   }
 
+  let qp = `?frameborder=0`;
+  if (edit && !sidebarOpen) {
+    qp = qp + '&rm=demo';
+  }
   const iframeSrc = file.webViewLink.replace(
     /\/(edit|view)\?usp=drivesdk/,
-    edit === true ? '/edit' : '/preview'
+    edit ? `/edit${qp}` : `/preview${qp}`
   );
 
-  const headSubtract = edit === true ? (!sidebarOpen ? 70 : 100) : 120;
+  const headSubtract = sidebarOpen ? 100 : 65;
 
   return (
     <div style={contentStyle}>

--- a/packages/website/src/pages/ContentPage/PreviewPage.tsx
+++ b/packages/website/src/pages/ContentPage/PreviewPage.tsx
@@ -3,6 +3,7 @@ import { InlineLoading } from 'carbon-components-react';
 import React, { CSSProperties, useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useManagedRenderStack } from '../../context/RenderStack';
+import { selectDocMode } from '../../reduxSlices/doc';
 import { selectSidebarOpen } from '../../reduxSlices/siderTree';
 import { DriveFile, HalfViewPreviewMimeTypes } from '../../utils';
 
@@ -16,6 +17,7 @@ function PreviewPage({ file, edit = false, renderStackOffset = 0 }: IPreviewPage
   const [isLoading, setIsLoading] = useState(true);
   const ref = useRef<HTMLIFrameElement>(null);
   const sidebarOpen = useSelector(selectSidebarOpen);
+  const docMode = useSelector(selectDocMode);
 
   useManagedRenderStack({
     depth: renderStackOffset,
@@ -62,7 +64,10 @@ function PreviewPage({ file, edit = false, renderStackOffset = 0 }: IPreviewPage
     edit ? `/edit${qp}` : `/preview${qp}`
   );
 
-  const headSubtract = sidebarOpen ? 100 : 65;
+  let headSubtract = sidebarOpen ? 100 : 65;
+  if (docMode === 'view') {
+    headSubtract += 60;
+  }
 
   return (
     <div style={contentStyle}>

--- a/packages/website/src/pages/FileAction.tsx
+++ b/packages/website/src/pages/FileAction.tsx
@@ -331,7 +331,7 @@ function FileAction() {
     return () => <TooltipHost content={mode}>{icon}</TooltipHost>;
   }
 
-  if (!rInner?.file || (!sidebarOpen && docMode === 'edit')) {
+  if (!rInner?.file || (!sidebarOpen && docMode !== 'view')) {
     return null;
   }
 
@@ -339,7 +339,7 @@ function FileAction() {
     <>
       <Stack horizontal>
         {rInner?.file.mimeType === MimeTypes.GoogleDocument && (
-          <Stack.Item>
+          <Stack.Item disableShrink>
             <Pivot onLinkClick={switchDocMode} selectedKey={docMode}>
               <PivotItem
                 itemKey="view"
@@ -352,8 +352,8 @@ function FileAction() {
             </Pivot>
           </Stack.Item>
         )}
-        {docMode === 'view' && (
-          <Stack.Item disableShrink grow={10}>
+        {(
+          <Stack.Item disableShrink grow={1} style={{ paddingLeft: '1em' }}>
             {rInner?.file.mimeType === MimeTypes.GoogleFolder ? (
               <CommandBar items={commandBarItems.concat(commandBarOverflowItems)} />
             ) : (
@@ -362,12 +362,12 @@ function FileAction() {
           </Stack.Item>
         )}
         {docMode !== 'view' && (
-          <Stack.Item disableShrink grow={10}>
+          <Stack.Item disableShrink grow={1}>
             <Tags tags={tags} file={rInner!.file} />
           </Stack.Item>
         )}
       </Stack>
-      {revisionsEnabled && <Revisions file={rInner!.file} />}
+      {docMode === 'view' && revisionsEnabled && <Revisions file={rInner!.file} />}
       {docMode === 'view' && <Tags tags={tags} file={rInner!.file} />}
     </>
   );

--- a/packages/website/src/pages/FileAction.tsx
+++ b/packages/website/src/pages/FileAction.tsx
@@ -112,7 +112,9 @@ function FileAction() {
 
   if (lastFileId !== (rInner?.file.id ?? '')) {
     setLastFileId(rInner?.file.id ?? '');
-    dispatch(setDocMode('view'));
+    if (docMode !== 'view') {
+      dispatch(setDocMode('view'));
+    }
     setRevisionsEnabled(false);
   }
 
@@ -318,9 +320,8 @@ function FileAction() {
         const modePathPiece = mode === 'view' ? '' : mode;
         history.push(`/view/${rInner?.file.id}/${modePathPiece}`);
       }
-      dispatch(setDocMode(mode as DocMode));
     },
-    [dispatch, history, rInner?.file]
+    [history, rInner?.file]
   );
 
   if (commandBarItems.length === 0 && commandBarOverflowItems.length === 0) {

--- a/packages/website/src/pages/FileAction.tsx
+++ b/packages/website/src/pages/FileAction.tsx
@@ -21,6 +21,7 @@ import { useRender } from '../context/RenderStack';
 import useFileMeta from '../hooks/useFileMeta';
 import responsiveStyle from '../layout/responsive.module.scss';
 import { selectDocMode, setDocMode } from '../reduxSlices/doc';
+import { selectSidebarOpen } from '../reduxSlices/siderTree';
 import { canChangeSettings, canEdit, extractTags, DocMode, DriveFile, MimeTypes } from '../utils';
 import { folderPageId } from './ContentPage/FolderPage';
 import { showCreateFile } from './FileAction.createFile';
@@ -101,6 +102,7 @@ function FileAction() {
   const [lastFileId, setLastFileId] = useState('');
   const dispatch = useDispatch();
   const docMode = useSelector(selectDocMode);
+  const sidebarOpen = useSelector(selectSidebarOpen);
 
   const history = useHistory();
 
@@ -329,7 +331,7 @@ function FileAction() {
     return () => <TooltipHost content={mode}>{icon}</TooltipHost>;
   }
 
-  if (!rInner?.file) {
+  if (!rInner?.file || (!sidebarOpen && docMode === 'edit')) {
     return null;
   }
 

--- a/packages/website/src/pages/Page.tsx
+++ b/packages/website/src/pages/Page.tsx
@@ -21,10 +21,10 @@ function Page(props: PageProps) {
   const id = useUpdateSiderFromPath('id');
   const { file, loading, error } = useFileMeta(id);
   const dispatch = useDispatch();
-  if (props.docMode) {
+  const docMode = useSelector(selectDocMode);
+  if (props.docMode && props.docMode !== docMode) {
     dispatch(setDocMode(props.docMode));
   }
-  const docMode = useSelector(selectDocMode);
 
   useTitle((file) => {
     if (file && file?.id !== getConfig().REACT_APP_ROOT_ID) {

--- a/packages/website/src/pages/Page.tsx
+++ b/packages/website/src/pages/Page.tsx
@@ -11,7 +11,6 @@ import { DocMode } from '../utils';
 import ContentPage from './ContentPage';
 import FileAction from './FileAction';
 import FileBreadcrumb from './FileBreadcrumb';
-import styles from './Page.module.scss';
 import RightContainer from './RightContainer';
 
 interface PageProps {
@@ -37,10 +36,14 @@ function Page(props: PageProps) {
 
   return (
     <RightContainer>
-      <div className={styles.actionBar}>
-        {docMode === 'view' && <FileBreadcrumb file={file} />}
+      <>
+        {docMode === 'view' && (
+          <div style={{ paddingTop: '0.3rem' }}>
+            <FileBreadcrumb file={file} />
+          </div>
+        )}
         <FileAction />
-      </div>
+      </>
       {loading && <InlineLoading description="Loading file metadata..." />}
       {!loading && !!error && error}
       {<ContentPage loading={loading || error ? id : null} file={file} />}


### PR DESCRIPTION
Google Docs already has a lot of toolbars in edit mode.
So don't display FileAction toolbars at all when the sidebar is closed.
The user can toggle the sidebar or go back in their browser.
Do the same for preview.

When in preview or edit mode, don't show the title and minimize the FileAction to one row.

For the edit view when the sidebar is closed, use `?rm=demo` which reduces the menus.