### PR TITLE
fix Google Doc link parsing

### DIFF
--- a/packages/website/src/utils/gapi.ts
+++ b/packages/website/src/utils/gapi.ts
@@ -11,7 +11,9 @@ export function handleGapiError(e: any): Error {
 }
 
 export function parseDriveLink(url: string) {
-  let m = url.match(/^https:\/\/docs\.google\.com\/[^/]+(\/u\/\d+)?\/d\/([^/]+)\/edit/);
+  let m = url.match(
+    /^https:\/\/docs\.google\.com\/[^/]+(\/u\/\d+)?\/d\/([^/]+)(\/)?(edit|preview)?/
+  );
   if (!m) {
     m = url.match(/^https:\/\/drive\.google\.com\/[^/]+(\/u\/\d+)?\/[^/]+\/([^/]+)$/);
   }


### PR DESCRIPTION
previously assumed it was a /edit link

I think a docs.google.com link should not be an much risk for a false positive. Probably we should allow .* after the document id instead of matching on edit and preview.