### PR TITLE
fetch without the ky dependency

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -18,7 +18,6 @@
     "easings.scss": "^0.3.1",
     "eventemitter2": "^6.4.3",
     "formik": "^2.2.5",
-    "ky": "^0.25.1",
     "lodash": "^4.17.20",
     "natural-compare-lite": "^1.4.0",
     "office-ui-fabric-react": "^7.153.2",

--- a/packages/website/src/config.ts
+++ b/packages/website/src/config.ts
@@ -1,5 +1,3 @@
-import ky from 'ky';
-
 type INavMenuItem = INavMenuLink | INavMenuGroup;
 export interface INavMenuLink {
   type: 'link';
@@ -88,11 +86,19 @@ export async function loadConfig() {
   }
 }
 
+async function getJSON(url: string): Promise<any> {
+  const rsp = await fetch(url, { headers: { Accept: 'application/json' } });
+  if (!rsp.ok) {
+    throw new Error(`Fetch error ${rsp.statusText}`);
+  }
+  return rsp.json();
+}
+
 async function overwriteConfig() {
   try {
-    const url = `${process.env.PUBLIC_URL}/config.json?_=${Date.now()}`;
-    const oc = (await ky(url).json()) as Record<string, any>;
-    for (const key in oc) {
+    const url = `${window.location.origin}/config.json?_=${Date.now()}`;
+    const oc = await getJSON(url);
+    for (const key in oc as Record<string, any>) {
       if (oc[key]) {
         config[key] = oc[key];
       }
@@ -100,6 +106,7 @@ async function overwriteConfig() {
     localStorage?.setItem(configStorageKey, JSON.stringify(config));
   } catch (e) {
     if (config.REACT_APP_USE_CONFIG_FILE) {
+      console.error('overwriteConfig', e);
       throw e;
     }
   }


### PR DESCRIPTION
This dependency is only used once so is easy to remove.

This was tested locally by testing without a config.json, with an empty config.json, and with a config.json with a key and value pair and seeing the k/v pair show up in the saved localstorage item 'app-config'