### PR TITLE
fix comment comparison white space issue

### DIFF
--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -335,6 +335,10 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
   }, [file.id, dispatch, file.name]);
 
   useEffect(() => {
+    function removeSpace(s: string): string {
+      return s.replaceAll(/\s+/g, ' ');
+    }
+
     const comments = docComments.filter((comment) => comment.resolved !== true);
     if (comments.length === 0) {
       return;
@@ -342,7 +346,7 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
 
     const commentLookup = {};
     for (const comment of comments) {
-      commentLookup[comment.content ?? ''] = comment;
+      commentLookup[removeSpace(comment.content ?? '')] = comment;
     }
     const replyLookup = {};
     let i = 0;
@@ -370,10 +374,10 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
         }
         origTextPieces.push(child.textContent || '');
       }
-      const origText = origTextPieces.join('\n');
-      const comment = commentLookup[origText];
+      const lookupText = removeSpace(origTextPieces.join('\n'));
+      const comment = commentLookup[lookupText];
       if (comment) {
-        delete commentLookup[origText];
+        delete commentLookup[lookupText];
         for (const child of parent.children) {
           parent.removeChild(child);
         }
@@ -387,16 +391,17 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
         );
         // need to delete all the replies
         for (const reply of comment.replies) {
-          replyLookup[reply.content] = reply;
+          replyLookup[removeSpace(reply.content ?? '')] = reply;
         }
-      } else if (replyLookup[origText]) {
-        delete replyLookup[origText];
+      } else if (replyLookup[lookupText]) {
+        delete replyLookup[lookupText];
         // note that we no longer link replies back to the text
         // So delete those supers as well
         document.getElementById((commentLink.getAttribute('href') ?? '').slice(1))?.remove();
         parent.remove();
       } else {
-        console.debug('did not find comment for', origText);
+        console.debug('did not find comment for', lookupText);
+        // console.debug(replyLookup);
       }
     }
 


### PR DESCRIPTION
convert multiple spaces into one

A comment was not getting recognized and upgraded due to a white space mismatch.