### PR TITLE
fix the iframe load event

### DIFF
--- a/packages/website/src/pages/ContentPage/index.tsx
+++ b/packages/website/src/pages/ContentPage/index.tsx
@@ -24,14 +24,23 @@ function ContentPage({ loading, file, shortCutFile, renderStackOffset = 0 }: ICo
   }
 
   if (PreviewableMimeTypes.indexOf(file?.mimeType ?? '') > -1) {
-    return <PreviewPage file={file!} renderStackOffset={renderStackOffset} />;
+    // Use key to force an unmount when the file changes
+    // This resets event handlers
+    return <PreviewPage key={file!.id!} file={file!} renderStackOffset={renderStackOffset} />;
   }
 
   switch (file?.mimeType ?? '') {
     case MimeTypes.GoogleDocument:
       if (docMode !== 'view') {
         const edit = docMode === 'edit';
-        return <PreviewPage edit={edit} file={file!} renderStackOffset={renderStackOffset} />;
+        return (
+          <PreviewPage
+            key={file!.id!}
+            edit={edit}
+            file={file!}
+            renderStackOffset={renderStackOffset}
+          />
+        );
       }
       return <DocPage file={file!} renderStackOffset={renderStackOffset} />;
     case MimeTypes.GoogleFolder:


### PR DESCRIPTION
Some use functions can have hidden dependencies between DOM and data.
An easy solution is to remount the component.
This can be achieved by setting the key= attribute.

The issue this resolves is that the Loading... part did not go away.