### PR TITLE
don't wrap the filename

### DIFF
--- a/packages/website/src/pages/FileBreadcrumb.tsx
+++ b/packages/website/src/pages/FileBreadcrumb.tsx
@@ -11,7 +11,7 @@ import styles from './FileBreadcrumb.module.scss';
 
 export function CurrentFileBreadcrumbItem({ file }: { file: DriveFile }) {
   return (
-    <Stack wrap verticalAlign="center" horizontal tokens={{ childrenGap: 8 }}>
+    <Stack verticalAlign="center" horizontal tokens={{ childrenGap: 8 }}>
       <span>{file.name}</span>
       <DriveIcon file={file} />
       {file.mimeType === MimeTypes.GoogleShortcut && <ShortcutIcon />}


### PR DESCRIPTION
After this change the directory hierarchy will shrink if the file name is too large. This might be a bad change for mobile? But the directory hierarchy can still be clicked on to view it as a menu.