### PR TITLE
folderpage readme and fileactions

### DIFF
--- a/packages/website/src/pages/ContentPage/index.tsx
+++ b/packages/website/src/pages/ContentPage/index.tsx
@@ -20,7 +20,7 @@ function ContentPage({ loading, file, shortCutFile, renderStackOffset = 0 }: ICo
   // Assume a document for speed in that case.
   // We might be wrong, but that will get corrected without issue.
   if (loading !== null) {
-    return <DocPage file={{ id: loading }} renderStackOffset={renderStackOffset} />;
+    return <DocPage key={loading} file={{ id: loading }} renderStackOffset={renderStackOffset} />;
   }
 
   if (PreviewableMimeTypes.indexOf(file?.mimeType ?? '') > -1) {
@@ -42,7 +42,7 @@ function ContentPage({ loading, file, shortCutFile, renderStackOffset = 0 }: ICo
           />
         );
       }
-      return <DocPage file={file!} renderStackOffset={renderStackOffset} />;
+      return <DocPage key={file?.id} file={file!} renderStackOffset={renderStackOffset} />;
     case MimeTypes.GoogleFolder:
       return (
         <FolderPage

--- a/packages/website/src/pages/Page.tsx
+++ b/packages/website/src/pages/Page.tsx
@@ -42,7 +42,7 @@ function Page(props: PageProps) {
             <FileBreadcrumb file={file} />
           </div>
         )}
-        <FileAction />
+        <FileAction key={file?.id} />
       </>
       {loading && <InlineLoading description="Loading file metadata..." />}
       {!loading && !!error && error}

--- a/packages/website/src/utils/gapi.ts
+++ b/packages/website/src/utils/gapi.ts
@@ -104,19 +104,22 @@ export interface FolderChildrenDisplaySettings {
 export const FOLDER_CHILDREN_SETTINGS_PROPERTY = 'folderChildrenSettings';
 
 export function parseFolderChildrenDisplaySettings(file: DriveFile): FolderChildrenDisplaySettings {
-  const def: FolderChildrenDisplaySettings = {
+  const placeHolder: FolderChildrenDisplaySettings = {
     displayInSidebar: true,
     displayInContent: 'list',
   };
-  let parsed = {};
   const value = file.appProperties?.[FOLDER_CHILDREN_SETTINGS_PROPERTY] ?? '';
   if (value) {
-    parsed = JSON.parse(value);
+    const parsed = JSON.parse(value);
+    for (const key of Object.keys(placeHolder)) {
+      if (typeof parsed[key] === typeof placeHolder[key]) {
+        placeHolder[key] = parsed[key];
+      } else {
+        delete placeHolder[key]
+      }
+    }
   }
-  return {
-    ...def,
-    ...parsed,
-  };
+  return placeHolder;
 }
 
 export function fileIsFolderOrFolderShortcut(file: DriveFile) {


### PR DESCRIPTION
On the folder page with a readme,
if the files are to be shown as a list (default)
show a vertical split view of files and the README.
Otherwise files are shown at the top.

Fileactions are now always for the folder
when there is a folder with a README.