### PR TITLE
when toggling a folder in the sidebar, don't select it

### DIFF
--- a/packages/website/src/layout/Sider.tsx
+++ b/packages/website/src/layout/Sider.tsx
@@ -178,7 +178,10 @@ function Sider_({ isExpanded = true }: { isExpanded?: boolean }) {
   const id = useSelector(selectActiveId) ?? getConfig().REACT_APP_ROOT_ID;
 
   const handleToggle = useCallback(
-    (_, node: TreeNodeProps) => {
+    (ev: React.MouseEvent, node: TreeNodeProps) => {
+      // handleToggle is called before onSelect
+      // This will stop the event from getting to onSelect
+      ev.stopPropagation();
       if (node.isExpanded) {
         dispatch(expand([node.id ?? '']));
       } else {


### PR DESCRIPTION
This makes it possible to navigate in the sidebar
without altering the main display