### PR TITLE
show folders in the sidebar but click to show files

### DIFF
--- a/packages/website/src/hooks/useLoadDriveFiles.tsx
+++ b/packages/website/src/hooks/useLoadDriveFiles.tsx
@@ -30,7 +30,7 @@ export default function useLoadDriveFiles() {
         console.debug(
           `useLoadDriveFiles files.list (page #${i + 1})`,
           getConfig().REACT_APP_ROOT_DRIVE_ID,
-          resp
+          resp.result.files?.length
         );
         dispatch(updateFiles(resp.result.files ?? []));
         if (resp.result.nextPageToken) {


### PR DESCRIPTION
There are 2 ways to show files.
* Click on an already active folder (2nd click).
* Click a new '...': this avoids changing the folder page.

Files are loaded from cache and refreshed since useFolderFilesMeta has this behavior now.