### PR TITLE
better fullscreen mode

### DIFF
--- a/packages/website/src/layout/Sider.module.scss
+++ b/packages/website/src/layout/Sider.module.scss
@@ -14,7 +14,8 @@ $sider-width: 300px;
   bottom: 0;
 
   overflow-y: auto;
-  padding: 1rem 0;
+  padding-top: 1rem;
+  padding-left: 0rem;
   background-color: $ui-01;
 
   z-index: 7999;
@@ -63,6 +64,6 @@ $sider-width: 300px;
 
 @include for-size(phone-up) {
   .content.isExpanded {
-    margin-left: $sider-width;
+    margin-left: $sider-width + 10px;
   }
 }

--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -693,11 +693,11 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
   }
 
   return (
-    <div id="doc-page-outer" style={{ maxWidth: '50rem' }}>
+    <div id="doc-page-outer" style={{ maxWidth: '50rem', }}>
       <div>
         <div
           id="gdoc-html-content"
-          style={{ marginTop: '1rem', maxWidth: '50rem' }}
+          style={{ marginTop: '1rem', maxWidth: '50rem', marginLeft: '1rem' }}
           dangerouslySetInnerHTML={{ __html: docContent }}
           onClick={handleDocContentClick}
         />

--- a/packages/website/src/pages/FileBreadcrumb.tsx
+++ b/packages/website/src/pages/FileBreadcrumb.tsx
@@ -97,7 +97,7 @@ function FileBreadcrumb({ file, extraItems }: IFileBreadcrumbProps) {
   }, [paths, extraItems]);
   if ((items.length ?? 0) > 0) {
     return (
-      <>
+      <div style={{ marginLeft: '1rem'}}>
         <div className={responsiveStyle.hideInPhone}>
           <Breadcrumb items={items} />
         </div>
@@ -106,7 +106,7 @@ function FileBreadcrumb({ file, extraItems }: IFileBreadcrumbProps) {
             <CurrentFileBreadcrumbItem file={file!} />
           </div>
         )}
-      </>
+      </div>
     );
   } else {
     return null;

--- a/packages/website/src/pages/RightContainer.module.scss
+++ b/packages/website/src/pages/RightContainer.module.scss
@@ -1,9 +1,1 @@
 @import '../mixin.scss';
-
-.container {
-  padding-left: 1rem;
-
-  @include for-size(phone-and-tablet) {
-    padding-left: 1rem;
-  }
-}


### PR DESCRIPTION
When the sidebar is closed, view files in fullscreen mode.
For example this removes padding around viewing a presentation.

Also fix a bug where FileAction was not rendered when the sidebar
was closed and opened.