### PR TITLE
expand the file list on the README page to a table

### DIFF
--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -332,6 +332,7 @@ function highlightAndLinkComment(sup: HTMLElement){
     // inline-block fixes this.
     // We apply a textIndent fix to bulleted lists elsewhere
     // This does not play nicely with inline-block. so skip those
+    // TODO: we could try increasing the line-height
     if (!link.style.display && !span.parentElement?.style.textIndent) {
       link.style.display = 'inline-block';
     }

--- a/packages/website/src/pages/ContentPage/FolderPage.module.scss
+++ b/packages/website/src/pages/ContentPage/FolderPage.module.scss
@@ -9,8 +9,8 @@
   }
 
   ul {
-    margin-left: 1.3em;
-    list-style: disc;
+    margin-left: 0.3em;
+    list-style: none;
   }
 
   ol {
@@ -26,6 +26,13 @@
 
   li ul {
     list-style: circle;
+  }
+
+  ul:first-child {
+    padding-top: 0;
+  }
+  li {
+    padding-top: 0.4em;
   }
 }
 

--- a/packages/website/src/pages/ContentPage/index.tsx
+++ b/packages/website/src/pages/ContentPage/index.tsx
@@ -17,7 +17,7 @@ export interface IContentPageProps {
 
 interface PageProps {
   renderStackOffset: number;
-  key: string,
+  key: string;
   file: { id?: string };
 }
 

--- a/packages/website/src/pages/FileAction.tsx
+++ b/packages/website/src/pages/FileAction.tsx
@@ -206,7 +206,7 @@ function FileAction(props: { file?: DriveFile, allOverflow?: boolean }) {
     }
 
     return commands;
-  }, [file, outerFolder.file, tags.length, settingsCommand]);
+  }, [file, outerFolder.file, tags.length, settingsCommand, props.allOverflow]);
 
   const commandBarOverflowItems = useMemo(() => {
     const commands: ICommandBarItemProps[] = [];

--- a/packages/website/src/utils/icons.tsx
+++ b/packages/website/src/utils/icons.tsx
@@ -6,6 +6,7 @@ import {
   Edit16,
   Launch16,
   Link16,
+  Maximize16,
   OverflowMenuHorizontal16,
   View16,
   Settings16,
@@ -34,6 +35,7 @@ export function registerIcons() {
       StackedMove: <WatsonHealthStackedMove16 />,
       ColorGoogleDrive: <Icon icon={googleDrive} />,
       MdiFileEdit: <Icon icon={fileEdit} />,
+      Maximize: <Maximize16 />,
     },
   });
 }


### PR DESCRIPTION
 Users can now switch from the vertical split with list to the table view