### PR TITLE
folder page: user can switch between list and table view

### DIFF
--- a/packages/website/src/components/FileListTable.tsx
+++ b/packages/website/src/components/FileListTable.tsx
@@ -5,7 +5,7 @@ import { DriveFile, mdLink } from '../utils';
 import { DriveFileName, DriveIcon, Table } from '.';
 
 export interface IFileListTableProps {
-  files?: DriveFile[];
+  files: DriveFile[];
   openInNewWindow: boolean;
 }
 

--- a/packages/website/src/hooks/useFolderFilesMeta.tsx
+++ b/packages/website/src/hooks/useFolderFilesMeta.tsx
@@ -53,15 +53,16 @@ export function useFolderFilesMeta(id?: string) {
             fields: '*',
             pageSize: 1000,
           });
-          console.debug(`loadFolderFilesMetadata files.list (page #${i + 1})`, id, resp);
+          const newFiles = resp.result.files ?? [];
+          console.debug(`loadFolderFilesMetadata files.list (page #${i + 1})`, id, newFiles.length);
 
           if (reqRef.current !== checkpoint) {
             break;
           }
-          for (const file of resp.result.files ?? []) {
+          for (const file of newFiles) {
             files[file.id ?? ''] = file;
           }
-          dispatch(updateFiles(resp.result.files ?? []));
+          dispatch(updateFiles(newFiles));
           if (resp.result.nextPageToken) {
             pageToken = resp.result.nextPageToken;
           } else {

--- a/packages/website/src/pages/ContentPage/FolderPage.module.scss
+++ b/packages/website/src/pages/ContentPage/FolderPage.module.scss
@@ -44,6 +44,14 @@
   }
 }
 
+.tableView {
+  :global {
+    .ms-DetailsHeader {
+      padding-top: 0px;
+    }
+  }
+}
+
 .gdocLink {
   .gdocThumbnail {
     z-index: 0;

--- a/packages/website/src/pages/Settings/index.tsx
+++ b/packages/website/src/pages/Settings/index.tsx
@@ -5,10 +5,9 @@ import { useSelector } from 'react-redux';
 import useFileMeta from '../../hooks/useFileMeta';
 import useUpdateSiderFromPath from '../../hooks/useUpdateSiderFromPath';
 import { selectPageReloadToken } from '../../reduxSlices/pageReload';
-import { shouldShowFolderChildrenSettings, shouldShowTagSettings } from '../../utils';
+import { shouldShowTagSettings } from '../../utils';
 import FileBreadcrumb from '../FileBreadcrumb';
 import RightContainer from '../RightContainer';
-import SettingsChildrenDisplay from './Settings.childrenDisplay';
 import SettingsTag from './Settings.tags';
 
 function Settings() {
@@ -33,7 +32,6 @@ function Settings() {
       <div style={{ maxWidth: '30rem' }}>
         <Stack tokens={{ childrenGap: 50 }}>
           {shouldShowTagSettings(file) && <SettingsTag file={file!} />}
-          {shouldShowFolderChildrenSettings(file) && <SettingsChildrenDisplay file={file!} />}
         </Stack>
       </div>
     </RightContainer>

--- a/packages/website/src/utils/icons.tsx
+++ b/packages/website/src/utils/icons.tsx
@@ -7,6 +7,7 @@ import {
   Launch16,
   Link16,
   Maximize16,
+  Minimize16,
   OverflowMenuHorizontal16,
   View16,
   Settings16,
@@ -36,6 +37,7 @@ export function registerIcons() {
       ColorGoogleDrive: <Icon icon={googleDrive} />,
       MdiFileEdit: <Icon icon={fileEdit} />,
       Maximize: <Maximize16 />,
+      Minimize: <Minimize16 />,
     },
   });
 }


### PR DESCRIPTION
store their switch as a localstorage preference.

Remove the ability to customize the display preference for the folder.
This may be useful in a few cases. However, consider
1) 'hide' was only useful when displaying the README page.
We are now improving this view so that it is unecessary.
2) It can be confusing/frustrating for a user.
This means the user is not in control of how folders are displayed.
Peronsally I always want to see the table view
so for some users this was a bug rather than a feature.