### PR TITLE
use a normal link in the table view

### DIFF
--- a/packages/website/src/components/DriveFileName.tsx
+++ b/packages/website/src/components/DriveFileName.tsx
@@ -1,7 +1,9 @@
 import { Stack } from 'office-ui-fabric-react';
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { DriveFile, mdLink, MimeTypes } from '../utils';
-import { ShortcutIcon } from '.';
+import { DriveIcon } from './DriveIcon';
+import { ShortcutIcon } from './ShortcutIcon';
 
 function DriveFileName_({ file }: { file: DriveFile }) {
   const link = mdLink.parse(file.name);
@@ -19,3 +21,32 @@ function DriveFileName_({ file }: { file: DriveFile }) {
 }
 
 export const DriveFileName = React.memo(DriveFileName_);
+
+export interface IFileInList {
+  file: DriveFile;
+  openInNewWindow: boolean;
+  children: any;
+}
+
+export function FileWithIcon({ file }: { file: DriveFile }) {
+  return (
+    <Stack verticalAlign="center" horizontal tokens={{ childrenGap: 8 }}>
+      <DriveIcon file={file} />
+      <DriveFileName file={file} />
+    </Stack>
+  );
+}
+
+export function FileLink({ file, openInNewWindow, children }: IFileInList) {
+  const link = mdLink.parse(file.name);
+  const target = openInNewWindow ? '_blank' : undefined;
+  return link ? (
+    <a href={link.url} target="_blank" rel="noreferrer">
+      {children}
+    </a>
+  ) : (
+    <Link to={`/view/${file.id}`} target={target}>
+      {children}
+    </Link>
+  );
+}

--- a/packages/website/src/components/FileListTable.tsx
+++ b/packages/website/src/components/FileListTable.tsx
@@ -2,7 +2,9 @@ import dayjs from 'dayjs';
 import { IColumn } from 'office-ui-fabric-react';
 import React, { useCallback, useMemo } from 'react';
 import { DriveFile, mdLink } from '../utils';
-import { DriveFileName, DriveIcon, Table } from '.';
+import { DriveFileName, FileLink } from './DriveFileName';
+import { DriveIcon } from './DriveIcon';
+import { Table } from './Table';
 
 export interface IFileListTableProps {
   files: DriveFile[];
@@ -35,7 +37,11 @@ export function FileListTable({ files, openInNewWindow }: IFileListTableProps) {
         name: 'Name',
         minWidth: 200,
         isRowHeader: true,
-        onRender: (item: DriveFile) => <DriveFileName file={item} />,
+        onRender: (item: DriveFile) => (
+          <FileLink file={item} openInNewWindow={openInNewWindow}>
+            <DriveFileName file={item} />
+          </FileLink>
+        ),
       },
       {
         key: 'create',
@@ -55,11 +61,19 @@ export function FileListTable({ files, openInNewWindow }: IFileListTableProps) {
       },
     ];
     return r;
-  }, []);
+  }, [openInNewWindow]);
 
+  let tableProps = {
+    items: files ?? [],
+    columns: columns,
+    getKey: getKey,
+  }
+  if (openInNewWindow) {
+    tableProps = Object.assign(tableProps, { onRowClicked: handleRowClick });
+  }
   return (
     <>
-      <Table items={files ?? []} columns={columns} onRowClicked={handleRowClick} getKey={getKey} />
+      <Table {...tableProps} />
       {!files?.length && <div style={{ marginTop: 16 }}>Folder is empty.</div>}
     </>
   );

--- a/packages/website/src/pages/ContentPage/FolderPage.tsx
+++ b/packages/website/src/pages/ContentPage/FolderPage.tsx
@@ -4,11 +4,11 @@ import { Stack, TooltipHost } from 'office-ui-fabric-react';
 import React, { useMemo, useState, MouseEventHandler } from 'react';
 import { useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { DriveFileName, DriveIcon, FileListTable, IFileListTableProps } from '../../components';
+import { FileWithIcon, FileLink, FileListTable, IFileListTableProps } from '../../components';
 import { useManagedRenderStack } from '../../context/RenderStack';
 import { useFolderFilesMeta, IFolderFilesMeta  } from '../../hooks/useFolderFilesMeta';
 import { selectMapIdToFile } from '../../reduxSlices/files';
-import { DriveFile, FolderChildrenDisplayMode, canEdit, mdLink, } from '../../utils';
+import { DriveFile, FolderChildrenDisplayMode, canEdit } from '../../utils';
 import styles from './FolderPage.module.scss';
 import ContentPage from '.';
 
@@ -37,31 +37,6 @@ interface IFolderAccordionProps extends IFolderFilesProps {
   open: boolean;
 }
 
-interface IFileInList {
-  file: DriveFile;
-  openInNewWindow: boolean;
-}
-
-function FileLink({ file, openInNewWindow }: IFileInList) {
-  const link = mdLink.parse(file.name);
-  const target = openInNewWindow ? '_blank' : undefined;
-  const inner = (
-    <Stack verticalAlign="center" horizontal tokens={{ childrenGap: 8 }}>
-      <DriveIcon file={file} />
-      <DriveFileName file={file} />
-    </Stack>
-  );
-  return link ? (
-    <a href={link.url} target="_blank" rel="noreferrer">
-      {inner}
-    </a>
-  ) : (
-    <Link to={`/view/${file.id}`} target={target}>
-      {inner}
-    </Link>
-  );
-}
-
 function FolderChildrenList({ files, openInNewWindow, clickExpandToTable }: IFolderListProps) {
   return (
     <div className={styles.content}>
@@ -74,7 +49,9 @@ function FolderChildrenList({ files, openInNewWindow, clickExpandToTable }: IFol
         {files.map((file: gapi.client.drive.File) => {
           return (
             <li key={file.id}>
-              <FileLink file={file} openInNewWindow={openInNewWindow} />
+              <FileLink file={file} openInNewWindow={openInNewWindow}>
+                <FileWithIcon file={file} />
+              </FileLink>
             </li>
           );
         })}

--- a/packages/website/src/pages/Search/SearchResult.tsx
+++ b/packages/website/src/pages/Search/SearchResult.tsx
@@ -21,7 +21,7 @@ export default function SearchResult() {
         <Typography.Title>Search: {result.value}</Typography.Title>
       </div>
       {(!result.loading || result.files.length > 0) && (
-        <FileListTable files={result.files} openInNewWindow />
+        <FileListTable files={result.files} openInNewWindow={false} />
       )}
       {result.loading && <InlineLoading description={`Searching...`} />}
     </RightContainer>


### PR DESCRIPTION
For Search, previously files opened in an external tab.
Now that we use a normal link, users can ctrl+click if they want this behavior.

The file name table cell is the link now.
Don't allow clicking other parts of the row.
This will be helpful for clicking on other table elements in the future