### PR TITLE
Only allow 3 folder file requests at the same time.

### DIFF
--- a/packages/website/src/hooks/useFileMeta.tsx
+++ b/packages/website/src/hooks/useFileMeta.tsx
@@ -45,7 +45,7 @@ export default function useFileMeta(id?: string) {
             driveId: id!,
             fields: '*',
           });
-          console.log('useFileMeta drives.get', respDrive);
+          console.debug('useFileMeta drives.get', respDrive.result);
           respFile.result.name = respDrive.result.name;
         } else {
           dispatch(updateFile(respFile.result));

--- a/packages/website/src/layout/Sider.tsx
+++ b/packages/website/src/layout/Sider.tsx
@@ -162,7 +162,7 @@ function nodeLabel(props: {
   isExpanded?: boolean;
   isActive?: boolean;
   filesShown?: boolean;
-  onFolderShowFiles?: (file: DriveFile) => void
+  onFolderShowFiles?: (file: DriveFile) => void;
 }): React.ReactNode {
   const { file } = props;
   let isChildrenHidden = false;
@@ -250,7 +250,7 @@ function ExpandedFolder(props: {
   onFolderShowFiles?: (file: DriveFile) => void;
 }) {
   const { file } = props;
-  const filesMeta = useFolderFilesMeta(file.id);
+  const filesMeta = useFolderFilesMeta(file.id!);
   const nonFolderCount = useMemo(() => {
     return (filesMeta.files ?? []).filter((file) => file.mimeType !== MimeTypes.GoogleFolder)
       .length;

--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -299,10 +299,7 @@ function removeLinkStyling(style: string): string {
 }
 
 // linkPreview performs blocking API calls
-async function linkPreview(
-  baseEl: HTMLElement,
-  cb?: (files: DriveFile[]) => void
-): Promise<DriveFile[]> {
+async function linkPreview(baseEl: HTMLElement): Promise<DriveFile[]> {
   const files = [] as DriveFile[];
   try {
     for (const link of baseEl.querySelectorAll('.' + styles.gdocLink)) {
@@ -329,11 +326,8 @@ async function linkPreview(
     }
   } catch (e) {
     console.error('linkPreview thumbnails', e);
-  } finally {
-    if (cb) {
-      cb(files);
-    }
   }
+
   return files;
 }
 
@@ -595,7 +589,7 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
 
           // link preview makes blocking API calls
           setTimeout(function () {
-            linkPreview(content, function (files) {
+            linkPreview(content).then(function (files) {
               setDocContent(content.innerHTML);
               setDocHtmlChangesFinished(content);
               const fileLookup = {};

--- a/packages/website/src/pages/ContentPage/FolderPage.tsx
+++ b/packages/website/src/pages/ContentPage/FolderPage.tsx
@@ -67,10 +67,10 @@ function FolderPage({ file, shortCutFile, renderStackOffset = 0 }: IFolderPagePr
   const mapIdToFile = useSelector(selectMapIdToFile);
   const openInNewWindow = useMemo(() => {
     // If current folder is not in the tree, open new window
-    return !mapIdToFile?.[file?.id ?? ''] && shortCutFile;
+    return !mapIdToFile?.[file?.id!] && shortCutFile;
   }, [mapIdToFile, file, shortCutFile]);
 
-  const filesMeta = useFolderFilesMeta(file.id);
+  const filesMeta = useFolderFilesMeta(file.id!);
   const { loading, error } = filesMeta;
   const files = useMemo(() => filesMeta.files ?? [], [filesMeta]);
 

--- a/packages/website/src/utils/docHeaders.test.ts
+++ b/packages/website/src/utils/docHeaders.test.ts
@@ -1,13 +1,13 @@
-import { MakeTree, MakeTree2, DocHeader, treeHeading } from "./docHeaders"
+import { MakeTree, DocHeader, treeHeading } from './docHeaders';
 
 let counter = 0;
 function h(level: number): DocHeader {
-    counter += 1;
-    return {
-        level,
-        text: counter.toString(),
-        id: "id",
-    }
+  counter += 1;
+  return {
+    level,
+    text: counter.toString(),
+    id: 'id',
+  }
 }
 
 const h1: DocHeader = h(1);
@@ -16,43 +16,43 @@ const h3: DocHeader = h(3);
 const h4: DocHeader = h(4);
 
 describe('MakeTree', () => {
-    it('empty headers', () => {
-        expect(MakeTree([])).toEqual([])
-    })
+  it('empty headers', () => {
+    expect(MakeTree([])).toEqual([])
+  });
 
-    it('one level of headers', () => {
-        expect(MakeTree([h1])).toEqual([h1])
-        expect(MakeTree([h1, h1])).toEqual([h1, h1])
-        expect(MakeTree([h2, h2])).toEqual([h2, h2])
-    })
+  it('one level of headers', () => {
+    expect(MakeTree([h1])).toEqual([h1])
+    expect(MakeTree([h1, h1])).toEqual([h1, h1])
+    expect(MakeTree([h2, h2])).toEqual([h2, h2])
+  });
 
-    it('multiple levels of headers', () => {
-        expect(MakeTree([h1, h2])).toEqual([
-          treeHeading(h1, [h2])
-        ])
+  it('multiple levels of headers', () => {
+    expect(MakeTree([h1, h2])).toEqual([
+      treeHeading(h1, [h2])
+    ]);
 
-        expect(MakeTree([h1, h2, h1])).toEqual([
-          treeHeading(h1, [h2]),
-          h1,
-        ])
+    expect(MakeTree([h1, h2, h1])).toEqual([
+      treeHeading(h1, [h2]),
+      h1,
+    ]);
 
-        expect(MakeTree([h1, h2, h1, h2])).toEqual([
-          treeHeading(h1, [h2]),
-          treeHeading(h1, [h2]),
-        ])
-    })
+    expect(MakeTree([h1, h2, h1, h2])).toEqual([
+      treeHeading(h1, [h2]),
+      treeHeading(h1, [h2]),
+    ]);
+  })
 
-    it('regession test', () => {
-        let result = MakeTree([h1, h2, h3, h3, h2, h3, h4])
-        expect(result).toEqual([
-          treeHeading(h1, [
-            treeHeading(h2, [h3, h3]),
-            treeHeading(h2, [
-                treeHeading(h3, [h4])
-            ]),
-          ]),
-        ])
-    })
+  it('regession test', () => {
+    let result = MakeTree([h1, h2, h3, h3, h2, h3, h4])
+    expect(result).toEqual([
+      treeHeading(h1, [
+        treeHeading(h2, [h3, h3]),
+        treeHeading(h2, [
+            treeHeading(h3, [h4])
+        ]),
+      ]),
+    ]);
+  })
 })
 
-export {}
+export {};

--- a/packages/website/src/utils/index.ts
+++ b/packages/website/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './showModal';
 export * from './store';
 export * from './doc';
 export * from './file';
+export * from './requestQueue';

--- a/packages/website/src/utils/requestQueue.test.ts
+++ b/packages/website/src/utils/requestQueue.test.ts
@@ -1,0 +1,53 @@
+import { MakeRequestQueue } from './requestQueue';
+
+function timeout(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('requestQueue', () => {
+  it('await requests', async () => {
+    let requestRan = 0;
+    async function request() {
+      requestRan += 1;
+      await timeout(1);
+      return;
+    }
+    const enq = MakeRequestQueue();
+    enq(request);
+    expect(requestRan).toEqual(1);
+    enq(request);
+    expect(requestRan).toEqual(2);
+    enq(request);
+    expect(requestRan).toEqual(3);
+    enq(request);
+    expect(requestRan).toEqual(3);
+  });
+
+  it('enque requests', async () => {
+    let requestRan = 0;
+    async function request() {
+      requestRan += 1;
+      await timeout(5);
+      return;
+    }
+    const enc = MakeRequestQueue();
+    enc(request);
+    expect(requestRan).toEqual(1);
+    enc(request);
+    expect(requestRan).toEqual(2);
+    enc(request);
+    expect(requestRan).toEqual(3);
+    enc(request);
+    expect(requestRan).toEqual(3);
+    enc(request);
+    expect(requestRan).toEqual(3);
+    enc(request);
+    expect(requestRan).toEqual(3);
+    enc(request);
+    expect(requestRan).toEqual(3);
+    enc(request);
+    expect(requestRan).toEqual(3);
+    enc(request);
+    expect(requestRan).toEqual(3);
+  });
+});

--- a/packages/website/src/utils/requestQueue.ts
+++ b/packages/website/src/utils/requestQueue.ts
@@ -1,0 +1,26 @@
+// Only allow 3 simultaneous ongoing requests at the same time
+export function MakeRequestQueue(): (cb: () => Promise<void>) => void {
+  const queue = [] as (() => Promise<void>)[];
+  let active = 0;
+  async function enqueueRequest(cb: () => Promise<void>): Promise<void> {
+    queue.push(cb);
+    return runQueue();
+  }
+
+  async function runQueue() {
+    if (active > 2) {
+      return;
+    }
+    const cb = queue.shift();
+    if (!cb) {
+      return;
+    }
+    active += 1;
+    cb().finally(() => {
+      active -= 1;
+      runQueue();
+    });
+  }
+
+  return enqueueRequest;
+}


### PR DESCRIPTION
Opening up the tree and exposing a lot of folders was
getting error responses due to gapi throttling.