### PR TITLE
fix links on mobile

### DIFF
--- a/packages/website/src/App.tsx
+++ b/packages/website/src/App.tsx
@@ -31,7 +31,7 @@ import {
   closeSidebar,
   openSidebar,
 } from './reduxSlices/siderTree';
-import { history } from './utils';
+import { history, isTouchScreen } from './utils';
 
 function DriveFilesLoader({ children }) {
   useLoadDriveFiles();
@@ -145,21 +145,29 @@ function App() {
                 <Route exact path="/">
                   <Page />
                 </Route>
-                <Route path="/view/:id/edit">
-                  <Page docMode="edit" />
-                </Route>
-                <Route path="/view/:id/preview">
-                  <Page docMode="preview" />
-                </Route>
                 <Route exact path="/view/:id/view">
                   <Page docMode="view" />
-                </Route>
-                <Route exact path="/view/:id/versions">
-                  <Page docMode="edit" versions={true} />
                 </Route>
                 <Route exact path="/view/:id/settings">
                   <Settings />
                 </Route>
+                {isTouchScreen
+                  ? [
+                      <Redirect to="/view/:id/view" from="/view/:id/preview" />,
+                      <Redirect to="/view/:id/view" from="/view/:id/edit" />,
+                      <Redirect to="/view/:id/view" from="/view/:id/versions" />,
+                    ]
+                  : [
+                      <Route path="/view/:id/edit">
+                        <Page docMode="edit" />
+                      </Route>,
+                      <Route path="/view/:id/preview">
+                        <Page docMode="preview" />
+                      </Route>,
+                      <Route exact path="/view/:id/versions">
+                        <Page docMode="edit" versions={true} />
+                      </Route>,
+                  ]}
                 <Route path="/view/:id">
                   <Page />
                 </Route>

--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -19,7 +19,7 @@ import {
   DriveLink,
 } from '../../reduxSlices/doc';
 import { selectSidebarOpen } from '../../reduxSlices/siderTree';
-import { DriveFile, canEdit, parseDriveLink, MimeTypes } from '../../utils';
+import { DriveFile, canEdit, isTouchScreen, parseDriveLink, MimeTypes } from '../../utils';
 import { fromHTML, MakeTree } from '../../utils/docHeaders';
 import styles from './DocPage.module.scss';
 
@@ -386,7 +386,8 @@ function externallyLinkHeaders(baseEl: HTMLElement, file: DriveFile) {
   function headerLink(headerId: string): HTMLAnchorElement {
     let link = document.createElement('a');
     const path = editable ? 'edit' : 'preview';
-    const href = `/view/${fileId}/${path}#heading=${headerId}`;
+    const base = isTouchScreen ? 'https://docs.google.com/document/d' : '/view';
+    const href = `${base}/${fileId}/${path}#heading=${headerId}`;
     link.href = href;
     link.dataset['__gdoc_id'] = fileId;
     return link;
@@ -960,8 +961,15 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
       if (id) {
         ev.preventDefault();
         if ((target as HTMLElement).nodeName === 'A') {
-          const u = new URL((target as HTMLAnchorElement).href);
-          history.push(u.pathname + u.search + u.hash);
+          const hrefAttr = target.getAttribute('href');
+          console.log('opening target', hrefAttr);
+          if (hrefAttr?.[0] === '/' && hrefAttr?.[1] !== '/') {
+            const u = new URL((target as HTMLAnchorElement).href);
+            history.push(u.pathname + u.search + u.hash);
+          } else {
+            // For touchscreen preview/edit we open externally in gdocs app
+            window.open((target as HTMLAnchorElement).href, '_blank');
+          }
         } else {
           history.push(`/view/${id}`);
         }

--- a/packages/website/src/pages/FileAction.tsx
+++ b/packages/website/src/pages/FileAction.tsx
@@ -28,6 +28,7 @@ import {
   DriveFile,
   MimeTypes,
   docModes,
+  isTouchScreen,
 } from '../utils';
 import { folderPageId } from './ContentPage/FolderPage';
 import { showCreateFile } from './FileAction.createFile';
@@ -36,27 +37,6 @@ import styles from './FileAction.module.scss';
 import { showMoveFile } from './FileAction.moveFile';
 import { showRenameFile } from './FileAction.renameFile';
 import { showTrashFile } from './FileAction.trashFile';
-
-function detectTouchscreen() {
-  if (window.PointerEvent && 'maxTouchPoints' in navigator) {
-    // if Pointer Events are supported, just check maxTouchPoints
-    if (navigator.maxTouchPoints > 0) {
-      return true;
-    }
-  } else {
-    // no Pointer Events...
-    if (window.matchMedia && window.matchMedia('(any-pointer:coarse)').matches) {
-      // check for any-pointer:coarse which mostly means touchscreen
-      return true;
-    } else if (window.TouchEvent || 'ontouchstart' in window) {
-      // last resort - check for exposed touch events API / event handler
-      return true;
-    }
-  }
-  return false;
-}
-
-const isTouchScreen = detectTouchscreen();
 
 function Revisions(props: { file: DriveFile }) {
   const revs: Array<gapi.client.drive.Revision> = [];

--- a/packages/website/src/pages/Page.tsx
+++ b/packages/website/src/pages/Page.tsx
@@ -38,7 +38,7 @@ function Page(props: PageProps) {
     }
   }, file);
 
-  const fullScreenMode = (file: DriveFile) => {
+  function fullScreenMode(file: DriveFile) {
     if (!file?.mimeType) {
       return false;
     }

--- a/packages/website/src/utils/index.ts
+++ b/packages/website/src/utils/index.ts
@@ -9,3 +9,24 @@ export * from './store';
 export * from './doc';
 export * from './file';
 export * from './requestQueue';
+
+function detectTouchscreen() {
+  if (window.PointerEvent && 'maxTouchPoints' in navigator) {
+    // if Pointer Events are supported, just check maxTouchPoints
+    if (navigator.maxTouchPoints > 0) {
+      return true;
+    }
+  } else {
+    // no Pointer Events...
+    if (window.matchMedia && window.matchMedia('(any-pointer:coarse)').matches) {
+      // check for any-pointer:coarse which mostly means touchscreen
+      return true;
+    } else if (window.TouchEvent || 'ontouchstart' in window) {
+      // last resort - check for exposed touch events API / event handler
+      return true;
+    }
+  }
+  return false;
+}
+
+export const isTouchScreen = detectTouchscreen();


### PR DESCRIPTION
redirect mobile to the view doc mode
open header links externally:
that will open in the GDocs mobile app

closes #136