### PR TITLE
use an accordion in the sidebar

### DIFF
--- a/packages/website/src/layout/Sider.module.scss
+++ b/packages/website/src/layout/Sider.module.scss
@@ -20,6 +20,13 @@ $sider-width: 300px;
   z-index: 7999;
 
   :global {
+    .bx--accordion__content {
+      padding: 0;
+    }
+
+    .bx--tree {
+      font-size: 14px;
+    }
     .bx--label {
       padding-left: 1rem;
     }

--- a/packages/website/src/layout/Sider.tsx
+++ b/packages/website/src/layout/Sider.tsx
@@ -1,5 +1,5 @@
-import { CollapseAll16, Launch16, } from '@carbon/icons-react';
-import { InlineLoading, SkeletonText } from 'carbon-components-react';
+import { CollapseAll16, Launch16 } from '@carbon/icons-react';
+import { Accordion, AccordionItem, InlineLoading, SkeletonText } from 'carbon-components-react';
 import TreeView, { TreeNode, TreeNodeProps } from 'carbon-components-react/lib/components/TreeView';
 import cx from 'classnames';
 import { Stack, Pivot, PivotItem } from 'office-ui-fabric-react';
@@ -321,8 +321,6 @@ function Sider_({ isExpanded = true }: { isExpanded?: boolean }) {
 
   const id = useSelector(selectActiveId) ?? getConfig().REACT_APP_ROOT_ID;
 
-  const [sidebarTab, setSidebarTab] = useState('directories');
-
   const handleToggle = useCallback(
     (ev: React.MouseEvent, node: TreeNodeProps) => {
       // handleToggle is called before onSelect
@@ -384,26 +382,6 @@ function Sider_({ isExpanded = true }: { isExpanded?: boolean }) {
     }
   }
 
-  function switchTab(item): void {
-    const tab = item.props['itemKey'];
-    setSidebarTab(tab);
-  }
-
-  /* auto-switching is not always wanted 
-  const activeFile = mapIdToFile[id];
-  useEffect(
-    function autoSwitchToOutline() {
-      if (!activeFile) { return; }
-      if (activeFile.mimeType === MimeTypes.GoogleDocument) { setSidebarTab('outline'); }
-    },
-    [activeFile]
-  );
-  */
-
-  function renderPivotOutline() {
-    return <span style={{ fontWeight: 600 }}>Document Outline</span>;
-  }
-
   return (
     <div className={cx(styles.sider, { [styles.isExpanded]: isExpanded })}>
       <HeaderExtraActionsForMobile />
@@ -417,63 +395,58 @@ function Sider_({ isExpanded = true }: { isExpanded?: boolean }) {
           <InlineLoading description={`Error: ${error.message}`} status="error" />
         </div>
       )}
-      <Pivot onLinkClick={switchTab} selectedKey={sidebarTab}>
-        <PivotItem alwaysRender={true} itemKey="directories" headerText="Table of Contents">
-          {!loading && !error && (
-            <div style={{ marginTop: '0.5rem' }}>
-              <TreeView
-                label="Table of Contents"
-                hideLabel={true}
-                selected={selected}
-                active={id}
-                id={'tree-toc'}
-              >
-                {renderChildren(
-                  id,
-                  mapIdToFile,
-                  mapIdToChildren,
-                  onFolderShowFiles,
-                  showFiles,
-                  getConfig().REACT_APP_ROOT_ID,
-                  expanded,
-                  handleToggle
-                )}
-              </TreeView>
+      <Accordion>
+        {driveLinks.length > 0 && (
+          <AccordionItem title="Links">
+            <div style={{ padding: '1rem' }}>
+              <FolderChildrenList
+                files={driveLinks.map((dl) => dl.file).filter((f) => f) as DriveFile[]}
+              />
             </div>
-          )}
-        </PivotItem>
-        {(headerTreeNodes.length > 0 || driveLinks.length > 0) && (
-          <PivotItem itemKey="outline" onRenderItemLink={renderPivotOutline}>
-            {headerTreeNodes.length > 0 && (
-              <div style={{ marginTop: '0.5rem' }}>
-                <TreeView
-                  label="Document Outline"
-                  hideLabel={true}
-                  selected={[headerTreeNodes[0].key?.toString() ?? 0]}
-                  id="tree-document-headers"
-                >
-                  <Stack
-                    style={{ padding: '0.5rem', display: 'flex', justifyContent: 'center' }}
-                    verticalAlign="center"
-                    horizontal
-                  >
-                    <p>{file?.name}</p>
-                  </Stack>
-                  {headerTreeNodes}
-                </TreeView>
-              </div>
-            )}
-            {driveLinks.length > 0 && (
-              <div style={{ marginTop: '1em', marginLeft: '1em' }}>
-                <h4>Links in Document</h4>
-                <FolderChildrenList
-                  files={driveLinks.map((dl) => dl.file).filter((f) => f) as DriveFile[]}
-                />
-              </div>
-            )}
-          </PivotItem>
+          </AccordionItem>
         )}
-      </Pivot>
+        {headerTreeNodes.length > 0 && (
+          <AccordionItem title="Outline">
+            <TreeView
+              label="Document Outline"
+              hideLabel={true}
+              selected={[headerTreeNodes[0].key?.toString() ?? 0]}
+              id="tree-document-headers"
+            >
+              <Stack
+                style={{ padding: '0.5rem', display: 'flex', justifyContent: 'center' }}
+                verticalAlign="center"
+                horizontal
+              >
+                <p>{file?.name}</p>
+              </Stack>
+              {headerTreeNodes}
+            </TreeView>
+          </AccordionItem>
+        )}
+        {!loading && !error && (
+          <AccordionItem open={true} title="All Folders">
+            <TreeView
+              label="Table of Contents"
+              hideLabel={true}
+              selected={selected}
+              active={id}
+              id={'tree-toc'}
+            >
+              {renderChildren(
+                id,
+                mapIdToFile,
+                mapIdToChildren,
+                onFolderShowFiles,
+                showFiles,
+                getConfig().REACT_APP_ROOT_ID,
+                expanded,
+                handleToggle
+              )}
+            </TreeView>
+          </AccordionItem>
+        )}
+      </Accordion>
     </div>
   );
 }

--- a/packages/website/src/pages/ContentPage/DocPage.tsx
+++ b/packages/website/src/pages/ContentPage/DocPage.tsx
@@ -3,24 +3,28 @@ import { InlineLoading } from 'carbon-components-react';
 import cx from 'classnames';
 import { unzipSync, strFromU8 } from 'fflate';
 import { Stack } from 'office-ui-fabric-react';
-import React, { useCallback, useEffect, useState, useMemo } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import Avatar from 'react-avatar';
 import { useDispatch, useSelector } from 'react-redux';
 import { withRouter } from 'react-router';
 import { useHistory } from 'react-router-dom';
 import { useManagedRenderStack } from '../../context/RenderStack';
 import {
+  addDriveLinks,
   setHeaders,
   setDriveLinks,
   setComments,
   selectComments,
+  selectDriveLinksLookup,
   setFile,
   setNoFile,
   DriveLink,
 } from '../../reduxSlices/doc';
 import { selectSidebarOpen } from '../../reduxSlices/siderTree';
-import { DriveFile, canEdit, isTouchScreen, parseDriveLink, MimeTypes } from '../../utils';
+import { DriveFile, MimeTypes } from '../../utils';
 import { fromHTML, MakeTree } from '../../utils/docHeaders';
+import { prettify, rewriteLink } from '../../utils/docMarkup';
+import { escapeHtml, isModifiedEvent } from '../../utils/html';
 import styles from './DocPage.module.scss';
 
 export interface IDocPageProps {
@@ -40,276 +44,38 @@ function strToUint8Array(binary_string: string): Uint8Array {
   return bytes;
 }
 
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#039;');
-}
-
-function isModifiedEvent(event) {
-  return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
-}
-
-const monoFF = ['source code', 'courier', 'mono', 'consolas', 'inconsolata'];
-
-function removeUnsupportedFonts(el: HTMLElement) {
-  const ff = el.style.fontFamily;
-  if (ff) {
-    const fonts = (document as any).fonts;
-    const fs = el.style.fontSize || '11pt';
-    var font = `${fs} ${ff}`;
-    if (fonts && fonts.check && !fonts.check(font)) {
-      // console.log('removing unsupported font', font, el, el.textContent);
-      el.style.fontFamily = '';
-    }
-  }
-}
-
-// Remove all font families, except for some monospace fonts.
-function monoFontsOnly(el: HTMLElement) {
-  const ff = el.style.fontFamily.toLowerCase();
-  let isMonoFont = false;
-  for (const f of monoFF) {
-    if (ff.indexOf(f) > -1) {
-      isMonoFont = true;
-      break;
-    }
-  }
-
-  el.style.fontFamily = '';
-  if (isMonoFont) {
-    el.classList.add('__gdoc_monospace');
-  }
-}
-
-const bgColors = {
-  white: 'white',
-  '#ffffff': 'white',
-  'rgb(255, 255, 255)': 'white',
-  'rgb(255,255,255)': 'white',
-};
-
-function cleanElem(el: HTMLElement, inherit: AncestorContext): void {
-  if (inherit.inTable && !inherit.inList) {
-    monoFontsOnly(el);
-  }
-  removeUnsupportedFonts(el);
-  // Remove unnecessary background colors.
-  // These can cause text above/below to be cutoff (vertically).
-  // This has been seen after running Chrome's tranlsate
-  const elBgColor = el.style.backgroundColor;
-  if (
-    inherit.parentBgColor === elBgColor ||
-    bgColors[inherit.parentBgColor] === bgColors[elBgColor]
-  ) {
-    el.style.backgroundColor = '';
-  }
-}
-
-type AncestorContext = {
-  inTable: boolean;
-  inList: boolean;
-  parentBgColor: string;
-};
-
-// For modifiers that want to forward properties of the ancestors
-function modifyDescendants(el: HTMLElement, inherit: AncestorContext) {
-  const current = {
-    parentBgColor: el.style.backgroundColor || inherit.parentBgColor,
-    inTable: inherit.inTable || el.nodeName === 'TABLE',
-    inList: inherit.inList || el.nodeName === 'LI',
-  };
-  cleanElem(el, current);
-
-  const childEl = el.firstElementChild as HTMLElement | null;
-  if (childEl) {
-    modifyDescendants(childEl, current);
-  }
-
-  const sibling = el.nextElementSibling as HTMLElement | null;
-  if (sibling) {
-    modifyDescendants(sibling, inherit);
-  }
-}
-
-const timing = false;
-function timed(msg: string, cb: () => void) {
-  if (!timing) {
-    cb();
-    return;
-  }
-  const t0 = performance.now();
-  cb();
-  const t1 = performance.now();
-  console.log(msg + ' took ' + (t1 - t0) + ' milliseconds.');
-}
-
-function rewriteLink(el: HTMLAnchorElement): DriveLink | null {
-  // Rewrite `https://www.google.com/url?q=`
-  if (el.href.indexOf('https://www.google.com/url') === 0) {
-    const url = new URL(el.href);
-    const newHref = url.searchParams.get('q');
-    if (newHref) {
-      el.href = newHref;
-    }
-  }
-
-  // Open Google Doc and Google Drive link inline, for other links open in new window.
-  const href = el.href;
-  const id = parseDriveLink(href);
-  if (id) {
-    const wikiHref = `/view/${id}`;
-    el.href = wikiHref;
-    el.dataset['__gdoc_id'] = id;
-    el.classList.add(styles.gdocLink);
-    return {
-      wikiLink: wikiHref,
-      driveLink: href,
-      linkText: el.innerText,
-      id: id,
-    };
-  }
-  if ((el.getAttribute('href') ?? '').indexOf('#') !== 0) {
-    el.target = '_blank';
-    el.classList.add('__gdoc_external_link');
-  }
-  return null;
-}
-
-function prettify(baseEl: HTMLElement, file?: DriveFile): DriveLink[] {
-  timed('padding fixes', () => {
-    for (const li of baseEl.querySelectorAll('li')) {
-      fixPaddingLi(li as HTMLLIElement);
-    }
-  });
-
-  timed('modify descendants', () => {
-    // The HTML export will not change the background color even if it is changed in the doc
-    let parentBgColor = 'white';
-    // The HTML export has only html elements
-    modifyDescendants(baseEl, { inList: false, inTable: false, parentBgColor });
-  });
-
-  timed('comments', () => {
-    for (const sup of baseEl.querySelectorAll('sup')) {
-      highlightAndLinkComment(sup);
-    }
-  });
-
-  let links = [] as DriveLink[];
-  timed('link rewrite', () => {
-    const elements = baseEl.getElementsByTagName('a');
-    for (const el of elements) {
-      const l = rewriteLink(el);
-      if (l) {
-        links.push(l);
-      }
-    }
-  });
-
-  if (file) {
-    timed('externally link headers', () => {
-      externallyLinkHeaders(baseEl, file);
-    });
-  }
-
-  return links;
-}
-
-const sourceSansPro = '"Source Sans Pro"';
-
-function isFontFamily(fontFamily, fontFamily2) {
-  if (fontFamily[0] !== '"') {
-    fontFamily = '"' + fontFamily + '"';
-  }
-  if (fontFamily2[0] !== '"') {
-    fontFamily2 = '"' + fontFamily2 + '"';
-  }
-  return fontFamily === fontFamily2;
-}
-
-// In some specific cases enormous padding gets added to both the top and bottom of a list
-// In other specific cases some spacing is missing
-// Do a lot of specific checks to avoid altering other docs where this is not a problem
-function fixPaddingLi(li: HTMLLIElement): boolean {
-  // The indent of the second line of the bullet point
-  // should match the first
-  li.style.textIndent = '-1em';
-  li.style.listStylePosition = 'inside';
-
-  const child = li.firstElementChild as HTMLElement | null;
-  if (!child || child.nodeName !== 'SPAN') {
-    return false;
-  }
-
-  // There is not much logic here.
-  // This works well based on testing specific examples.
-  const isArial = isFontFamily('Arial', li.style.fontFamily);
-  const arialChildPro = isFontFamily(sourceSansPro, child.style.fontFamily) && isArial;
-  const hasPadding = li.style.paddingTop && li.style.paddingBottom;
-  let shouldAddSpace = hasPadding && (isFontFamily(sourceSansPro, li.style.fontFamily) || arialChildPro);
-
-  if (!shouldAddSpace && isArial) {
-    const grandChild = child.firstElementChild;
-    // Add a little spacing to links with underlines
-    if (grandChild && grandChild.nodeName === 'A') {
-      if ((grandChild as HTMLAnchorElement).style.textDecoration === 'inherit') {
-        if (parseInt(li.style.lineHeight) === 1) {
-          li.style.lineHeight = '1.3';
-          return true;
-        }
-      }
-    }
-  }
-
-  if (!shouldAddSpace) {
-    return false;
-  }
-
-  // Although there is too much padding, there is not enough line spacing
-  // 1.5 is already recommended for accessibility
-  if (parseInt(li.style.lineHeight) < 1.5) {
-    li.style.lineHeight = '1.5';
-  }
-  if (parseInt(li.style.fontSize) > parseInt(child.style.fontSize)) {
-    child.style.fontSize = '';
-  }
-  if (hasPadding) {
-    if (arialChildPro || li.parentElement?.nodeName === 'OL') {
-      li.style.paddingTop = '0pt';
-      li.style.paddingBottom = '0pt';
-    } else {
-      li.style.paddingTop = '4pt';
-      li.style.paddingBottom = '5pt';
-    }
-  }
-  return true;
-}
-
-function removeLinkStyling(style: string): string {
-  if (!style.includes('text-decoration')) {
-    style = style + ';text-decoration: none';
-  }
-  if (!style.match(/(^|[; ])color:/)) {
-    style = style + ';color: rgb(0, 0, 0);';
-  }
-  return style;
-}
+type DriveFileLookup = { [fileId: string]: DriveFile };
 
 // linkPreview performs blocking API calls
-async function linkPreview(baseEl: HTMLElement): Promise<DriveFile[]> {
-  const files = [] as DriveFile[];
+async function linkPreview(
+  baseEl: HTMLElement,
+  driveFileLookup?: DriveFileLookup
+): Promise<DriveLink[]> {
+  const files: { [fileId: string]: DriveFile } = driveFileLookup ?? {};
+  const driveLinks: DriveLink[] = [];
+
   try {
-    for (const link of baseEl.querySelectorAll('.' + styles.gdocLink)) {
-      const id = (link as HTMLElement).dataset?.['__gdoc_id'];
-      if (id) {
+    const linkElems = baseEl.classList.contains(styles.gdocLink)
+      ? [baseEl]
+      : baseEl.querySelectorAll('.' + styles.gdocLink)
+    for (const linkEl of linkElems) {
+      const link = linkEl as HTMLAnchorElement;
+      const id = link.dataset?.['__gdoc_id'];
+      if (id && !files[id]) {
         const fields = 'id,name,thumbnailLink,mimeType,iconLink';
         const req = { fileId: id, supportsAllDrives: true, fields };
         const rsp = await gapi.client.drive.files.get(req);
-        files.push(rsp.result);
+        files[id] = rsp.result;
+        console.log('linkPreview got file', rsp.result.name, id);
+
+        driveLinks.push({
+          file: rsp.result,
+          wikiLink: link.href,
+          driveLink: link.dataset?.['orig_href'] || link.href,
+          linkText: link.innerText,
+          id: id,
+        })
+
         const imgSrc = rsp.result.thumbnailLink;
         if (!imgSrc) {
           if (rsp.result.mimeType !== MimeTypes.GoogleFolder) {
@@ -329,133 +95,7 @@ async function linkPreview(baseEl: HTMLElement): Promise<DriveFile[]> {
     console.error('linkPreview thumbnails', e);
   }
 
-  return files;
-}
-
-// Highlight commented text just as in Google Docs.
-// Link to the comment text at the bottom of the doc.
-function highlightAndLinkComment(sup: HTMLElement){
-  const supLink = sup.children?.[0];
-  if (supLink?.id.startsWith('cmnt_')) {
-    const span = sup.previousElementSibling as HTMLElement;
-    if (!span || span.nodeName !== 'SPAN') {
-      if (span && span.id.startsWith('cmnt_')) {
-        // There are multiple sups next to eachother for replies
-        // This removes the replies
-        sup.remove();
-      }
-      return;
-    }
-
-    const link = document.createElement('a');
-    const href = supLink.getAttribute('href');
-    if (!href) {
-      console.error('no href for a link');
-      return;
-    }
-    link.setAttribute('href', href);
-    for (const name of span.getAttributeNames()) {
-      link.setAttribute(name, span.getAttribute(name) ?? '');
-    }
-    let style = span.getAttribute('style') || '';
-    // The linked text should not be styled like a link.
-    // The highlight already indicates it is a link like in Google Docs.
-    link.setAttribute('style', removeLinkStyling(style));
-    if (!link.style.backgroundColor) {
-      link.style.backgroundColor = 'rgb(255, 222, 173)';
-    }
-    // The highlight can obscure other content
-    // inline-block fixes this.
-    // We apply a textIndent fix to bulleted lists elsewhere
-    // This does not play nicely with inline-block. so skip those
-    // TODO: we could try increasing the line-height
-    if (!link.style.display && !span.parentElement?.style.textIndent) {
-      link.style.display = 'inline-block';
-    }
-    link.innerHTML = span.innerHTML;
-    link.id = supLink.id;
-    link.dataset['gdocwiki_comment_id'] = href.slice(1);
-    sup.remove();
-    span.replaceWith(link);
-  }
-}
-
-function externallyLinkHeaders(baseEl: HTMLElement, file: DriveFile) {
-  const fileId = file.id!;
-  const editable = canEdit(file);
-  function headerLink(headerId: string): HTMLAnchorElement {
-    let link = document.createElement('a');
-    const path = editable ? 'edit' : 'preview';
-    const base = isTouchScreen ? 'https://docs.google.com/document/d' : '/view';
-    const href = `${base}/${fileId}/${path}#heading=${headerId}`;
-    link.href = href;
-    link.dataset['__gdoc_id'] = fileId;
-    return link;
-  }
-
-  function childrenArray(el: HTMLElement) {
-    return Array.from(el.childNodes) as HTMLElement[];
-  }
-  function everyNodeNamed(els: HTMLElement[], nodeName: string) {
-    return els.every((n) => n.nodeName === nodeName);
-  }
-
-  // Link from headers into the GDoc
-  const headers = Array.from(
-    baseEl.querySelectorAll('h1, h2, h3, h4, h5, h6')
-  ) as HTMLHeadingElement[];
-  for (const el of headers) {
-    let children = childrenArray(el);
-
-    // If a header is all links or spans with links, it is already a link, ignore it
-    if (
-      children.every(
-        (n) =>
-          n.nodeName === 'A' ||
-          (n.nodeName === 'SPAN' && everyNodeNamed(childrenArray(n as HTMLElement), 'A'))
-      )
-    ) {
-      continue;
-    }
-
-    if (children.every((n) => n.nodeName === 'SPAN')) {
-      let style: string | null = null;
-      for (const inner of children) {
-        if (!style) {
-          style = (inner as HTMLElement).getAttribute('style');
-        }
-        let link = headerLink(el.id);
-        link.innerHTML = (inner as HTMLElement).innerHTML;
-        for (const a of (inner as HTMLElement).attributes) {
-          link.setAttribute(a.name, a.value);
-        }
-        if (!link.style.textDecoration) {
-          link.style.textDecoration = 'none';
-        }
-        if (!link.style.color) {
-          link.style.color = 'rgb(0, 0, 0)';
-        }
-        el.appendChild(link);
-        el.removeChild(inner);
-      }
-      // Fix a Google Docs export bug
-      // Sometimes when there are multiple spans in the header
-      // Some of the span are missing the header styling
-      if (style) {
-        for (const child of el.childNodes) {
-          if (!(child as HTMLElement).getAttribute('style')) {
-            (child as HTMLElement).setAttribute('style', style);
-          }
-        }
-      }
-    } else {
-      const link = headerLink(el.id);
-      el.appendChild(link);
-      for (const inner of children) {
-        link.appendChild(inner);
-      }
-    }
-  }
+  return driveLinks;
 }
 
 interface UpgradedComment {
@@ -465,14 +105,22 @@ interface UpgradedComment {
 }
 
 function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
+  const docContentElement = useRef(null as null | HTMLBodyElement);
   const [docContent, setDocContent] = useState('');
+  const docContentHasBeenRendered = !!docContentElement.current;
+
   const [isLoading, setIsLoading] = useState(true);
   const [viewingComment, setViewingComment] = useState(null as string | null);
   const dispatch = useDispatch();
   const docComments = useSelector(selectComments);
   const sidebarOpen = useSelector(selectSidebarOpen);
+  const driveLinksLookup = useSelector(selectDriveLinksLookup);
   const history = useHistory();
   const [upgradedComments, setUpgradedComments] = useState([] as UpgradedComment[]);
+  const [readyForLinkPreview, setReadyForLinkPreview] = useState(false);
+  const [docHtmlChangesFinished, setDocHtmlChangesFinished] = useState(false);
+
+  const isSpreadSheet = file.mimeType === MimeTypes.GoogleSpreadsheet;
 
   useCallback(() => {
     if (file.name) {
@@ -570,8 +218,45 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
     [dispatch]
   );
 
-  const [docHtmlChangesFinished, setDocHtmlChangesFinished] = useState(
-    null as null | HTMLBodyElement
+  useEffect(
+    function doLinkPreview() {
+      const content = docContentElement.current;
+      if (!content) {
+        return;
+      }
+
+      linkPreview(content).then(function (newLinks) {
+        setDocContent(content.innerHTML);
+        dispatch(setDriveLinks(newLinks));
+        setDocHtmlChangesFinished(true);
+      });
+    },
+    [readyForLinkPreview, dispatch],
+  );
+
+  useEffect(
+    function doAlterHtml() {
+      async function alterHtml() {
+        const content = docContentElement.current;
+        if (!content) {
+          return;
+        }
+
+        // prettify could take a noticeable amount of time for a large doc on a slow device.
+        // So it is important to be in a separate useEffect
+        prettify(content, styles, file);
+        setDocContent(content.innerHTML);
+        setReadyForLinkPreview(true);
+      }
+
+      // check file.name: optimistic rendering initially sets only the id
+      if (!isSpreadSheet && docContentHasBeenRendered && file.name) {
+        alterHtml();
+      }
+    },
+    // file.name is needed in the dependencies
+    // optimistic rendering initially sets only the id
+    [file, file.name, isSpreadSheet, docContentHasBeenRendered, dispatch]
   );
 
   const setDocWithRichContent = useCallback(
@@ -581,41 +266,10 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
           MakeTree(Array.from(content.querySelectorAll('h1, h2, h3, h4, h5, h6')).map(fromHTML))
         )
       );
-
       setDocContent(content.innerHTML);
-      if (pretty) {
-        // prettify could take a noticeable amount of time for a large doc on a slow device.
-        // Using setTimeout gives an opportunity to do an initial render before running the code
-        setTimeout(function () {
-          const links = prettify(content, file);
-          dispatch(setDriveLinks(links));
-          setDocContent(content.innerHTML);
-
-          // link preview makes blocking API calls
-          setTimeout(function () {
-            linkPreview(content).then(function (files) {
-              setDocContent(content.innerHTML);
-              setDocHtmlChangesFinished(content);
-              const fileLookup = {};
-              for (const file of files) {
-                fileLookup[file.id ?? ''] = file;
-              }
-              const newLinks = links.map((link) => {
-                const file = fileLookup[link.id];
-                if (!file) {
-                  console.log('file not found for link', link);
-                  return link;
-                } else {
-                  return Object.assign({ file }, link);
-                }
-              });
-              dispatch(setDriveLinks(newLinks));
-            });
-          }, 1);
-        }, 1);
-      }
+      docContentElement.current = content;
     },
-    [file, dispatch]
+    [dispatch]
   );
 
   useEffect(
@@ -635,17 +289,21 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
 
       async function loadHtmlView() {
         setIsLoading(true);
+        // At least when in dev mode this needs to be reset
+        docContentElement.current = null;
         setDocWithPlainText('');
 
+        // TODO: this gets called multiple times on page load
+        // separate this out with only a dependency on file.id
         try {
-          if (file.mimeType === MimeTypes.GoogleSpreadsheet) {
+          if (isSpreadSheet) {
             const resp = await gapi.client.drive.files.export({
               alt: 'media',
               fileId: file.id!,
               mimeType: 'application/zip',
             });
             const decompressed = unzipSync(strToUint8Array(resp.body), {})
-            console.log('DocPage files.export zip', file.id, Object.keys(decompressed));
+            console.debug('DocPage files.export zip', file.id, Object.keys(decompressed));
             let html = '';
             let css = '';
             for (const k in decompressed) {
@@ -664,7 +322,7 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
               fileId: file.id!,
               mimeType: 'text/html',
             });
-            console.log('DocPage files.export', file.id);
+            console.debug('DocPage files.export', file.id);
             loadHtmlBody(resp.body, true);
           }
         } finally {
@@ -677,7 +335,7 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
         dispatch(setDriveLinks([]));
       };
     },
-    [file.id, file.mimeType, dispatch, setDocWithPlainText, setDocWithRichContent]
+    [file.id, isSpreadSheet, dispatch, setDocWithPlainText, setDocWithRichContent]
   );
 
   useEffect(
@@ -724,35 +382,38 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
     [file.id, file.name, match.params, history]
   );
 
-  useEffect(() => {
-    // When optimistically rendering the document, only an id is available.
-    // Avoid optimistically fetching comments as well.
-    // This API call would actually succeed against a folder
-    // but we wouldn't end up using the resulit.
-    if (!file.name) {
-      return;
-    }
-
-    async function loadComments() {
-      try {
-        // problem: this does not return all of the visible comments
-        const resp = await gapi.client.drive.comments.list({
-          fileId: file.id!,
-          includeDeleted: false,
-          fields: '*',
-          pageSize: 100,
-        });
-        const respComments = resp.result.comments ?? [];
-        dispatch(setComments(respComments));
-      } catch (e) {
-        console.error('error loading comments', e);
+  useEffect(
+    function doLoadComments() {
+      // When optimistically rendering the document, only an id is available.
+      // Avoid optimistically fetching comments as well.
+      // This API call would actually succeed against a folder
+      // but we wouldn't end up using the resulit.
+      if (!file.name) {
+        return;
       }
-    }
-    loadComments();
-    return function () {
-      dispatch(setComments([]));
-    };
-  }, [file.id, dispatch, file.name]);
+
+      async function loadComments() {
+        try {
+          // problem: this does not return all of the visible comments
+          const resp = await gapi.client.drive.comments.list({
+            fileId: file.id!,
+            includeDeleted: false,
+            fields: '*',
+            pageSize: 100,
+          });
+          const respComments = resp.result.comments ?? [];
+          dispatch(setComments(respComments));
+        } catch (e) {
+          console.error('error loading comments', e);
+        }
+      }
+      loadComments();
+      return function () {
+        dispatch(setComments([]));
+      };
+    },
+    [file.id, dispatch, file.name]
+  );
 
   // TODO: when using Google translate the comments could already be translated
   // We need to use the pre-inserted HTML
@@ -762,153 +423,205 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
   // We do not get the comments from the API for a re-opened comment thread.
   // AS per above should have a fallback, at least do not remove superscript links from text.
   useEffect(
-    function upgradeComments(): void {
-      function removeSpace(s: string): string {
-        return s.replaceAll(/\s+/g, '');
-      }
-
-      function replyText(reply: gapi.client.drive.Reply): string {
-        if (reply.action === 'resolve' && !reply.content?.startsWith('_Marked as done_')) {
-          return '_Marked as done_ ' + (reply.content ?? '');
+    function doUpgradeComments(): void {
+      async function upgradeComments() {
+        function removeSpace(s: string): string {
+          return s.replaceAll(/\s+/g, '');
         }
-        return reply.content ?? '';
+
+        function replyText(reply: gapi.client.drive.Reply): string {
+          if (reply.action === 'resolve' && !reply.content?.startsWith('_Marked as done_')) {
+            return '_Marked as done_ ' + (reply.content ?? '');
+          }
+          return reply.content ?? '';
+        }
+
+        const body = docContentElement.current;
+        if (!body) {
+          return;
+        }
+
+        // We would like to filter out resolve comments
+        // However, once a comment thread is resolved it may stay marked resolved
+        // Even after being re-opened
+        // We also won't see the replies after it is re-opened
+        const apiComments = docComments; // .filter((comment) => comment.resolved !== true);
+        if (apiComments.length === 0) {
+          return;
+        }
+
+        let newDriveLinks: DriveLink[] = [];
+        let fileLookup: { [fileId: string]: DriveFile } = {};
+        for (const id in driveLinksLookup) {
+          const f = driveLinksLookup[id].file;
+          if (f) {
+            fileLookup[id] = f;
+          }
+        }
+        const prettifyHtmlContent = async (htmlContent: string) => {
+          if (!htmlContent) {
+            return htmlContent;
+          }
+
+          const parser = new DOMParser();
+          const body = parser.parseFromString(htmlContent, 'text/html').body;
+          for (const el of body.getElementsByTagName('a')) {
+            rewriteLink(el, styles);
+            const newLinks = await linkPreview(el, fileLookup);
+            newDriveLinks = newDriveLinks.concat(newLinks);
+          }
+          return body.innerHTML;
+        }
+
+        const newComments: UpgradedComment[] = [];
+
+        const commentLookup: { [text: string]: gapi.client.drive.Comment[] } = {};
+        for (const comment of apiComments) {
+          const text = removeSpace(comment.content ?? '')
+          const multi = commentLookup[text];
+          if (multi) {
+            multi.push(comment);
+          } else {
+            commentLookup[text] = [comment];
+          }
+        }
+        const replyLookup: { [text: string]: gapi.client.drive.Comment[] } = {};
+        let i = 0;
+        while (true) {
+          i += 1;
+          const domId = '#cmnt' + i.toString();
+          const commentLink = body.querySelector(domId);
+          if (!commentLink) {
+            // console.debug(commentLookup);
+            // console.debug(replyLookup);
+            break;
+          }
+          let parent = commentLink.parentElement;
+          while (parent && parent.nodeName !== 'DIV') {
+            parent = parent.parentElement;
+          }
+          if (!parent) {
+            console.error('no parent for comment');
+            continue;
+          }
+          let origTextPieces = [commentLink.nextElementSibling?.textContent ?? ''];
+          for (const child of Array.from(parent.children).slice(1)) {
+            const textContent = child.textContent || '';
+            if (
+              textContent.startsWith('_Assigned to') ||
+              textContent.startsWith('_Reassigned to')
+            ) {
+              continue;
+            }
+            origTextPieces.push(textContent);
+          }
+          const lookupText = removeSpace(origTextPieces.join('\n'));
+          const comments = commentLookup[lookupText];
+          if (comments) {
+            if (comments.length === 1) {
+              delete commentLookup[lookupText];
+            }
+            const topHref = commentLink.getAttribute('href') ?? '#';
+            // console.log(topHref);
+            // console.log(body.querySelector(topHref));
+            const docTextNoSpace = removeSpace(
+              escapeHtml((body.querySelector(topHref) as HTMLElement | null)?.innerText ?? '')
+            );
+            let exactComment: null | gapi.client.drive.Comment = null;
+            if (docTextNoSpace) {
+              for (const comment of comments) {
+                const quotedNoSpace = removeSpace(comment.quotedFileContent?.value ?? '');
+                if (quotedNoSpace === docTextNoSpace) {
+                  exactComment = comment;
+                }
+              }
+            }
+            if (!exactComment) {
+              exactComment = comments.shift()!;
+              if (comments.length > 0) {
+                console.debug(
+                  'did not find exact',
+                  docTextNoSpace,
+                  'guessing',
+                  exactComment.quotedFileContent?.value
+                );
+              }
+              for (const comment of comments) {
+                console.debug('alternative', removeSpace(comment.quotedFileContent?.value ?? ''));
+              }
+            }
+
+            for (const child of parent.children) {
+              parent.removeChild(child);
+            }
+
+            let apiComment = exactComment;
+            if (exactComment.htmlContent) {
+              const html = await prettifyHtmlContent(exactComment.htmlContent);
+              apiComment = { ...exactComment, htmlContent: html };
+            }
+
+            // Create a lookup for all the replies.
+            // This will confirm that the replies in the DOM exist in our data.
+            if (apiComment.replies) {
+              const replies = [...apiComment.replies];
+              for (const [i, reply] of apiComment.replies.entries()) {
+                const replyNoSpace = removeSpace(replyText(reply));
+                const repliesForText = replyLookup[replyNoSpace];
+                if (repliesForText) {
+                  repliesForText.push(reply);
+                } else {
+                  replyLookup[replyNoSpace] = [reply];
+                }
+
+                if (reply.htmlContent) {
+                  const html = await prettifyHtmlContent(reply.htmlContent);
+                  replies[i] = { ...reply, htmlContent: html };
+                }
+              }
+              apiComment = { ...apiComment, replies }
+            }
+
+            newComments.push({
+              comment: apiComment,
+              topHref,
+              htmlId: commentLink.id,
+            });
+
+            parent.remove();
+          } else if (replyLookup[lookupText]) {
+            const replies = replyLookup[lookupText];
+            // Don't bother figuring out the exact correct reply.
+            replies.shift();
+            if (replies.length === 0) {
+              delete replyLookup[lookupText];
+            }
+            // note that we no longer link replies back to the text
+            // So delete those supers as well
+            (body.querySelector(
+              commentLink.getAttribute('href') ?? ''
+            ) as HTMLElement | null)?.remove();
+            parent.remove();
+          } else {
+            console.debug('did not find comment for', lookupText);
+            // console.debug(Object.keys(commentLookup));
+            // console.debug(replyLookup);
+          }
+        }
+
+        if (newDriveLinks.length > 0) {
+          dispatch(addDriveLinks(newDriveLinks));
+        }
+        setUpgradedComments(newComments);
+        setDocContent(body.innerHTML);
       }
 
       // wait for all other HTML alterations to complete
-      if (!docHtmlChangesFinished) {
-        return;
+      if (docHtmlChangesFinished) {
+        upgradeComments();
       }
-      const body = docHtmlChangesFinished;
-
-      // We would like to filter out resolve comments
-      // However, once a comment thread is resolved it may stay marked resolved
-      // Even after being re-opened
-      // We also won't see the replies after it is re-opened
-      const apiComments = docComments; // .filter((comment) => comment.resolved !== true);
-      if (apiComments.length === 0) {
-        return;
-      }
-
-      const newComments: UpgradedComment[] = [];
-
-      const commentLookup: { [text: string]: gapi.client.drive.Comment[] } = {};
-      for (const comment of apiComments) {
-        const text = removeSpace(comment.content ?? '')
-        const multi = commentLookup[text];
-        if (multi) {
-          multi.push(comment);
-        } else {
-          commentLookup[text] = [comment];
-        }
-      }
-      const replyLookup: { [text: string]: gapi.client.drive.Comment[] } = {};
-      let i = 0;
-      while (true) {
-        i += 1;
-        const domId = '#cmnt' + i.toString();
-        const commentLink = body.querySelector(domId);
-        if (!commentLink) {
-          // console.debug(commentLookup);
-          // console.debug(replyLookup);
-          break;
-        }
-        let parent = commentLink.parentElement;
-        while (parent && parent.nodeName !== 'DIV') {
-          parent = parent.parentElement;
-        }
-        if (!parent) {
-          console.error('no parent for comment');
-          continue;
-        }
-        let origTextPieces = [commentLink.nextElementSibling?.textContent ?? ''];
-        for (const child of Array.from(parent.children).slice(1)) {
-          if (child.textContent?.startsWith('_Assigned to')) {
-            continue;
-          }
-          origTextPieces.push(child.textContent || '');
-        }
-        const lookupText = removeSpace(origTextPieces.join('\n'));
-        const comments = commentLookup[lookupText];
-        if (comments) {
-          if (comments.length === 1) {
-            delete commentLookup[lookupText];
-          }
-          const topHref = commentLink.getAttribute('href') ?? '#';
-          // console.log(topHref);
-          // console.log(body.querySelector(topHref));
-          const docTextNoSpace = removeSpace(
-            escapeHtml((body.querySelector(topHref) as HTMLElement | null)?.innerText ?? '')
-          );
-          let exactComment: null | gapi.client.drive.Comment = null;
-          if (docTextNoSpace) {
-            for (const comment of comments) {
-              const quotedNoSpace = removeSpace(comment.quotedFileContent?.value ?? '');
-              if (quotedNoSpace === docTextNoSpace) {
-                exactComment = comment;
-              }
-            }
-          }
-          if (!exactComment) {
-            exactComment = comments.shift()!;
-            if (comments.length > 0) {
-              console.debug(
-                'did not find exact',
-                docTextNoSpace,
-                'guessing',
-                exactComment.quotedFileContent?.value
-              );
-            }
-            for (const comment of comments) {
-              console.debug('alternative', removeSpace(comment.quotedFileContent?.value ?? ''));
-            }
-          }
-
-          for (const child of parent.children) {
-            parent.removeChild(child);
-          }
-          newComments.push({
-            comment: exactComment,
-            topHref,
-            htmlId: commentLink.id,
-          });
-
-          // Create a lookup for all the replies.
-          // This will confirm that the replies in the DOM exist in our data.
-          for (const reply of exactComment.replies ?? []) {
-            const replyNoSpace = removeSpace(replyText(reply));
-            const replies = replyLookup[replyNoSpace];
-            if (replies) {
-              replies.push(reply);
-            } else {
-              replyLookup[replyNoSpace] = [reply];
-            }
-          }
-
-          parent.remove();
-        } else if (replyLookup[lookupText]) {
-          const replies = replyLookup[lookupText];
-          // Don't bother figuring out the exact correct reply.
-          replies.shift();
-          if (replies.length === 0) {
-            delete replyLookup[lookupText];
-          }
-          // note that we no longer link replies back to the text
-          // So delete those supers as well
-          (body.querySelector(
-            commentLink.getAttribute('href') ?? ''
-          ) as HTMLElement | null)?.remove();
-          parent.remove();
-        } else {
-          console.debug('did not find comment for', lookupText);
-          // console.debug(Object.keys(commentLookup));
-          // console.debug(replyLookup);
-        }
-      }
-
-      setDocContent(body.innerHTML);
-      setUpgradedComments(newComments);
     },
-    [docComments, isLoading, file.id, docHtmlChangesFinished]
+    [docComments, docHtmlChangesFinished, dispatch, driveLinksLookup]
   );
 
   useEffect(
@@ -994,40 +707,34 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
     );
   }
 
-  function hideNotViewing(comment: UpgradedComment) {
-    if (!!viewingComment && comment.htmlId !== viewingComment) {
-      return 'none';
-    }
-  }
-
   const fixSidebar = { position: 'fixed' as 'fixed', right: 0, left: sidebarOpen ? '320px' : '0' };
 
   return (
     <div id="doc-page-outer" onClick={handleDocContentClick}>
       <div
+        key="gdoc-html-content"
         id="gdoc-html-content"
         style={{ marginTop: '1rem' }}
         dangerouslySetInnerHTML={{ __html: docContent }}
       />
-      {!viewingComment && (
-        <div style={{ paddingTop: '30px' }}>
-          <hr />
-          <p>{upgradedComments.length === 0 ? 'No' : 'All'} Comments</p>
-          <hr style={{ marginBottom: '1rem' }} />
-          {upgradedComments.map((comment, i) => (
-            <div key={comment.htmlId}>
-              {i !== 0 && <hr />}
-              <CommentView key={comment.htmlId} fileId={file.id!} comment={comment} />
-            </div>
-          ))}
-        </div>
-      )}
+      <div key="upgradedComments" style={{ paddingTop: '30px' }}>
+        <hr />
+        <p>{upgradedComments.length === 0 ? 'No' : 'All'} Comments</p>
+        <hr style={{ marginBottom: '1rem' }} />
+        {upgradedComments.map((comment, i) => (
+          <div key={comment.htmlId}>
+            {i !== 0 && <hr />}
+            <CommentView key={comment.htmlId} fileId={file.id!} comment={comment} />
+          </div>
+        ))}
+      </div>
       {viewingComment && (
         <div
+          key="viewingComment"
           style={fixSidebar}
           className={cx(styles.commentsDrawer, { [styles.viewing]: !!viewingComment })}
         >
-          <div style={fixSidebar}>
+          <div key="view-comment-header" style={fixSidebar}>
             <hr />
             <Stack horizontal>
               <a
@@ -1037,22 +744,23 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
               >
                 <Close20 />
               </a>
-              <h4>Comments</h4>
+              <h4>View Comment</h4>
             </Stack>
             <hr />
           </div>
-          <div style={{ marginTop: '4.0rem' }}>
-            {upgradedComments.map((comment) => (
-              <div key={comment.htmlId} style={{ display: hideNotViewing(comment) }}>
-                {!viewingComment && <hr />}
-                <CommentView
-                  hideLinkBack={true}
-                  key={comment.htmlId}
-                  fileId={file.id!}
-                  comment={comment}
-                />
-              </div>
-            ))}
+          <div key="vew-comment-body" style={{ marginTop: '4.0rem' }}>
+            {upgradedComments.map((comment) =>
+              !!viewingComment && comment.htmlId !== viewingComment ? null : (
+                <div>
+                  <CommentView
+                    hideLinkBack={true}
+                    key={comment.htmlId}
+                    fileId={file.id!}
+                    comment={comment}
+                  />
+                </div>
+              )
+            )}
           </div>
         </div>
       )}
@@ -1062,8 +770,15 @@ function DocPage({ match, file, renderStackOffset = 0 }: IDocPageProps) {
 
 function scrollWithOffset(link: HTMLElement, fixedOffset = 100) {
   const rect = link.getBoundingClientRect();
-  const anchorOffset = window.pageYOffset + rect.top - fixedOffset;
-  window.scrollTo(window.pageXOffset, anchorOffset);
+  const fractionFromBottom = (window.innerHeight - rect.top) / window.innerHeight;
+  // The comment drawer is set to a height of 50%
+  if (fractionFromBottom > 0.5) {
+    return;
+  }
+  // Add a fixedOffset to give some room before the comments
+  const scrollToY = window.pageYOffset + fixedOffset + (0.5 - fractionFromBottom) * window.innerHeight;
+  console.log('scrollWithOffset', scrollToY, fixedOffset, window.pageYOffset);
+  window.scrollTo(window.pageXOffset, scrollToY);
 }
 
 interface CommentViewProps {

--- a/packages/website/src/reduxSlices/siderTree.ts
+++ b/packages/website/src/reduxSlices/siderTree.ts
@@ -130,4 +130,3 @@ export const selectSidebarOpen = (state: { tree: TreeState }) => state.tree.side
 export const selectShowFiles = (state: { tree: TreeState }) => state.tree.showFiles;
 
 export default slice.reducer;
-

--- a/packages/website/src/utils/docMarkup.ts
+++ b/packages/website/src/utils/docMarkup.ts
@@ -1,0 +1,344 @@
+import { canEdit, parseDriveLink, DriveFile } from './gapi';
+import { removeLinkStyling, fontFamilyEquals, isTouchScreen } from './html';
+
+const timing = false;
+function timed(msg: string, cb: () => void) {
+  if (!timing) {
+    cb();
+    return;
+  }
+  const t0 = performance.now();
+  cb();
+  const t1 = performance.now();
+  console.log(msg + ' took ' + (t1 - t0) + ' milliseconds.');
+}
+
+const monoFF = ['source code', 'courier', 'mono', 'consolas', 'inconsolata'];
+
+function removeUnsupportedFonts(el: HTMLElement) {
+  const ff = el.style.fontFamily;
+  if (ff) {
+    const fonts = (document as any).fonts;
+    const fs = el.style.fontSize || '11pt';
+    var font = `${fs} ${ff}`;
+    if (fonts && fonts.check && !fonts.check(font)) {
+      // console.log('removing unsupported font', font, el, el.textContent);
+      el.style.fontFamily = '';
+    }
+  }
+}
+
+// Remove all font families, except for some monospace fonts.
+function monoFontsOnly(el: HTMLElement) {
+  const ff = el.style.fontFamily.toLowerCase();
+  let isMonoFont = false;
+  for (const f of monoFF) {
+    if (ff.indexOf(f) > -1) {
+      isMonoFont = true;
+      break;
+    }
+  }
+
+  el.style.fontFamily = '';
+  if (isMonoFont) {
+    el.classList.add('__gdoc_monospace');
+  }
+}
+
+const bgColors = {
+  white: 'white',
+  '#ffffff': 'white',
+  'rgb(255, 255, 255)': 'white',
+  'rgb(255,255,255)': 'white',
+};
+
+function cleanElem(el: HTMLElement, inherit: AncestorContext): void {
+  if (inherit.inTable && !inherit.inList) {
+    monoFontsOnly(el);
+  }
+  removeUnsupportedFonts(el);
+  // Remove unnecessary background colors.
+  // These can cause text above/below to be cutoff (vertically).
+  // This has been seen after running Chrome's tranlsate
+  const elBgColor = el.style.backgroundColor;
+  if (
+    inherit.parentBgColor === elBgColor ||
+    bgColors[inherit.parentBgColor] === bgColors[elBgColor]
+  ) {
+    el.style.backgroundColor = '';
+  }
+}
+
+type AncestorContext = {
+  inTable: boolean;
+  inList: boolean;
+  parentBgColor: string;
+};
+
+// For modifiers that want to forward properties of the ancestors
+function modifyDescendants(el: HTMLElement, inherit: AncestorContext) {
+  const current = {
+    parentBgColor: el.style.backgroundColor || inherit.parentBgColor,
+    inTable: inherit.inTable || el.nodeName === 'TABLE',
+    inList: inherit.inList || el.nodeName === 'LI',
+  };
+  cleanElem(el, current);
+
+  const childEl = el.firstElementChild as HTMLElement | null;
+  if (childEl) {
+    modifyDescendants(childEl, current);
+  }
+
+  const sibling = el.nextElementSibling as HTMLElement | null;
+  if (sibling) {
+    modifyDescendants(sibling, inherit);
+  }
+}
+
+export function rewriteLink(el: HTMLAnchorElement, styles: any) {
+  // Rewrite `https://www.google.com/url?q=`
+  if (el.href.indexOf('https://www.google.com/url') === 0) {
+    const url = new URL(el.href);
+    const newHref = url.searchParams.get('q');
+    if (newHref) {
+      el.href = newHref;
+    }
+  }
+
+  // Open Google Doc and Google Drive link inline, for other links open in new window.
+  const href = el.href;
+  const id = parseDriveLink(href);
+  if (id) {
+    const wikiHref = `/view/${id}`;
+    el.href = wikiHref;
+    el.dataset['__gdoc_id'] = id;
+    el.dataset['orig_href'] = href;
+    el.classList.add(styles.gdocLink);
+  }
+
+  if ((el.getAttribute('href') ?? '').indexOf('#') !== 0) {
+    el.target = '_blank';
+    el.classList.add('__gdoc_external_link');
+  }
+}
+
+export function prettify(baseEl: HTMLElement, styles: any, file?: DriveFile) {
+  timed('padding fixes', () => {
+    for (const li of baseEl.querySelectorAll('li')) {
+      fixPaddingLi(li as HTMLLIElement);
+    }
+  });
+
+  timed('modify descendants', () => {
+    // The HTML export will not change the background color even if it is changed in the doc
+    let parentBgColor = 'white';
+    // The HTML export has only html elements
+    modifyDescendants(baseEl, { inList: false, inTable: false, parentBgColor });
+  });
+
+  timed('comments', () => {
+    for (const sup of baseEl.querySelectorAll('sup')) {
+      highlightAndLinkComment(sup);
+    }
+  });
+
+  timed('link rewrite', () => {
+    const elements = baseEl.getElementsByTagName('a');
+    for (const el of elements) {
+      rewriteLink(el, styles);
+    }
+  });
+
+  if (file) {
+    timed('externally link headers', () => {
+      externallyLinkHeaders(baseEl, file);
+    });
+  }
+}
+
+const sourceSansPro = '"Source Sans Pro"';
+
+// In some specific cases enormous padding gets added to both the top and bottom of a list
+// In other specific cases some spacing is missing
+// Do a lot of specific checks to avoid altering other docs where this is not a problem
+function fixPaddingLi(li: HTMLLIElement): boolean {
+  // The indent of the second line of the bullet point
+  // should match the first
+  li.style.textIndent = '-1em';
+  li.style.listStylePosition = 'inside';
+
+  const child = li.firstElementChild as HTMLElement | null;
+  if (!child || child.nodeName !== 'SPAN') {
+    return false;
+  }
+
+  // There is not much logic here.
+  // This works well based on testing specific examples.
+  const isArial = fontFamilyEquals('Arial', li.style.fontFamily);
+  const arialChildPro = fontFamilyEquals(sourceSansPro, child.style.fontFamily) && isArial;
+  const hasPadding = li.style.paddingTop && li.style.paddingBottom;
+  let shouldAddSpace =
+    hasPadding && (fontFamilyEquals(sourceSansPro, li.style.fontFamily) || arialChildPro);
+
+  if (!shouldAddSpace && isArial) {
+    const grandChild = child.firstElementChild;
+    // Add a little spacing to links with underlines
+    if (grandChild && grandChild.nodeName === 'A') {
+      if ((grandChild as HTMLAnchorElement).style.textDecoration === 'inherit') {
+        if (parseInt(li.style.lineHeight) === 1) {
+          li.style.lineHeight = '1.3';
+          return true;
+        }
+      }
+    }
+  }
+
+  if (!shouldAddSpace) {
+    return false;
+  }
+
+  // Although there is too much padding, there is not enough line spacing
+  // 1.5 is already recommended for accessibility
+  if (parseInt(li.style.lineHeight) < 1.5) {
+    li.style.lineHeight = '1.5';
+  }
+  if (parseInt(li.style.fontSize) > parseInt(child.style.fontSize)) {
+    child.style.fontSize = '';
+  }
+  if (hasPadding) {
+    if (arialChildPro || li.parentElement?.nodeName === 'OL') {
+      li.style.paddingTop = '0pt';
+      li.style.paddingBottom = '0pt';
+    } else {
+      li.style.paddingTop = '4pt';
+      li.style.paddingBottom = '5pt';
+    }
+  }
+  return true;
+}
+
+// Highlight commented text just as in Google Docs.
+// Link to the comment text at the bottom of the doc.
+function highlightAndLinkComment(sup: HTMLElement){
+  const supLink = sup.children?.[0];
+  if (supLink?.id.startsWith('cmnt_')) {
+    const span = sup.previousElementSibling as HTMLElement;
+    if (!span || span.nodeName !== 'SPAN') {
+      if (span && span.id.startsWith('cmnt_')) {
+        // There are multiple sups next to eachother for replies
+        // This removes the replies
+        sup.remove();
+      }
+      return;
+    }
+
+    const link = document.createElement('a');
+    const href = supLink.getAttribute('href');
+    if (!href) {
+      console.error('no href for a link');
+      return;
+    }
+    link.setAttribute('href', href);
+    for (const name of span.getAttributeNames()) {
+      link.setAttribute(name, span.getAttribute(name) ?? '');
+    }
+    let style = span.getAttribute('style') || '';
+    // The linked text should not be styled like a link.
+    // The highlight already indicates it is a link like in Google Docs.
+    link.setAttribute('style', removeLinkStyling(style));
+    if (!link.style.backgroundColor) {
+      link.style.backgroundColor = 'rgb(255, 222, 173)';
+    }
+    // The highlight can obscure other content
+    // inline-block fixes this.
+    // We apply a textIndent fix to bulleted lists elsewhere
+    // This does not play nicely with inline-block. so skip those
+    // TODO: we could try increasing the line-height
+    if (!link.style.display && !span.parentElement?.style.textIndent) {
+      link.style.display = 'inline-block';
+    }
+    link.innerHTML = span.innerHTML;
+    link.id = supLink.id;
+    link.dataset['gdocwiki_comment_id'] = href.slice(1);
+    sup.remove();
+    span.replaceWith(link);
+  }
+}
+
+function externallyLinkHeaders(baseEl: HTMLElement, file: DriveFile) {
+  const fileId = file.id!;
+  const editable = canEdit(file);
+  function headerLink(headerId: string): HTMLAnchorElement {
+    let link = document.createElement('a');
+    const path = editable ? 'edit' : 'preview';
+    const base = isTouchScreen ? 'https://docs.google.com/document/d' : '/view';
+    const href = `${base}/${fileId}/${path}#heading=${headerId}`;
+    link.href = href;
+    link.dataset['__gdoc_id'] = fileId;
+    return link;
+  }
+
+  function childrenArray(el: HTMLElement) {
+    return Array.from(el.childNodes) as HTMLElement[];
+  }
+  function everyNodeNamed(els: HTMLElement[], nodeName: string) {
+    return els.every((n) => n.nodeName === nodeName);
+  }
+
+  // Link from headers into the GDoc
+  const headers = Array.from(
+    baseEl.querySelectorAll('h1, h2, h3, h4, h5, h6')
+  ) as HTMLHeadingElement[];
+  for (const el of headers) {
+    let children = childrenArray(el);
+
+    // If a header is all links or spans with links, it is already a link, ignore it
+    if (
+      children.every(
+        (n) =>
+          n.nodeName === 'A' ||
+          (n.nodeName === 'SPAN' && everyNodeNamed(childrenArray(n as HTMLElement), 'A'))
+      )
+    ) {
+      continue;
+    }
+
+    if (children.every((n) => n.nodeName === 'SPAN')) {
+      let style: string | null = null;
+      for (const inner of children) {
+        if (!style) {
+          style = (inner as HTMLElement).getAttribute('style');
+        }
+        let link = headerLink(el.id);
+        link.innerHTML = (inner as HTMLElement).innerHTML;
+        for (const a of (inner as HTMLElement).attributes) {
+          link.setAttribute(a.name, a.value);
+        }
+        if (!link.style.textDecoration) {
+          link.style.textDecoration = 'none';
+        }
+        if (!link.style.color) {
+          link.style.color = 'rgb(0, 0, 0)';
+        }
+        el.appendChild(link);
+        el.removeChild(inner);
+      }
+      // Fix a Google Docs export bug
+      // Sometimes when there are multiple spans in the header
+      // Some of the span are missing the header styling
+      if (style) {
+        for (const child of el.childNodes) {
+          if (!(child as HTMLElement).getAttribute('style')) {
+            (child as HTMLElement).setAttribute('style', style);
+          }
+        }
+      }
+    } else {
+      const link = headerLink(el.id);
+      el.appendChild(link);
+      for (const inner of children) {
+        link.appendChild(inner);
+      }
+    }
+  }
+}

--- a/packages/website/src/utils/html.ts
+++ b/packages/website/src/utils/html.ts
@@ -1,0 +1,53 @@
+function detectTouchscreen() {
+  if (window.PointerEvent && 'maxTouchPoints' in navigator) {
+    // if Pointer Events are supported, just check maxTouchPoints
+    if (navigator.maxTouchPoints > 0) {
+      return true;
+    }
+  } else {
+    // no Pointer Events...
+    if (window.matchMedia && window.matchMedia('(any-pointer:coarse)').matches) {
+      // check for any-pointer:coarse which mostly means touchscreen
+      return true;
+    } else if (window.TouchEvent || 'ontouchstart' in window) {
+      // last resort - check for exposed touch events API / event handler
+      return true;
+    }
+  }
+  return false;
+}
+
+export const isTouchScreen = detectTouchscreen();
+
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
+export function isModifiedEvent(event) {
+  return !!(event.metaKey || event.altKey || event.ctrlKey || event.shiftKey);
+}
+
+export function removeLinkStyling(style: string): string {
+  if (!style.includes('text-decoration')) {
+    style = style + ';text-decoration: none';
+  }
+  if (!style.match(/(^|[; ])color:/)) {
+    style = style + ';color: rgb(0, 0, 0);';
+  }
+  return style;
+}
+
+export function fontFamilyEquals(fontFamily, fontFamily2) {
+  if (fontFamily[0] !== '"') {
+    fontFamily = '"' + fontFamily + '"';
+  }
+  if (fontFamily2[0] !== '"') {
+    fontFamily2 = '"' + fontFamily2 + '"';
+  }
+  return fontFamily === fontFamily2;
+}

--- a/packages/website/src/utils/index.ts
+++ b/packages/website/src/utils/index.ts
@@ -9,24 +9,4 @@ export * from './store';
 export * from './doc';
 export * from './file';
 export * from './requestQueue';
-
-function detectTouchscreen() {
-  if (window.PointerEvent && 'maxTouchPoints' in navigator) {
-    // if Pointer Events are supported, just check maxTouchPoints
-    if (navigator.maxTouchPoints > 0) {
-      return true;
-    }
-  } else {
-    // no Pointer Events...
-    if (window.matchMedia && window.matchMedia('(any-pointer:coarse)').matches) {
-      // check for any-pointer:coarse which mostly means touchscreen
-      return true;
-    } else if (window.TouchEvent || 'ontouchstart' in window) {
-      // last resort - check for exposed touch events API / event handler
-      return true;
-    }
-  }
-  return false;
-}
-
-export const isTouchScreen = detectTouchscreen();
+export * from './html';


### PR DESCRIPTION
There are 3 items in the sidebar (folders, outline, links).
Previously links were put under the outline tab but that
does not work well, particularly when the outline is larger then the screen.

Outline and links show up contextually for documents that have them.
We may include other contextual accordion items in the future.

Other fixes
* links from comments are prettified and shown in the links accordion item
* fix window scroll when viewing an individual comment
* fix avoid calling the export API multiple times
* get rid of setTimeout hacks