### PR TITLE
Fix permission scope

### DIFF
--- a/packages/website/src/index.tsx
+++ b/packages/website/src/index.tsx
@@ -37,7 +37,7 @@ async function main() {
           clientId: getConfig().REACT_APP_GAPI_CLIENT_ID,
           discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'],
           scope:
-            'https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/documents.readonly',
+            'https://www.googleapis.com/auth/drive.readonly https://www.googleapis.com/auth/documents.readonly',
           hosted_domain: getConfig().REACT_APP_GAPI_HOSTED_DOMAIN,
           cookie_policy: getConfig().REACT_APP_GAPI_COOKIE_POLICY,
         };


### PR DESCRIPTION
Hello! 
I'm Gergely Sipos from Aliz Tech. We recently started using gdocwiki, and so far we ❤ it! :)

We currently experiencing an issue, where our newer colleages have this error message:
![Képernyőkép 2021-10-14 131642](https://user-images.githubusercontent.com/4602237/137369692-52333a3e-dbe8-4aad-ac06-f9b4847dc6f3.png)

We checked and they have the necessary permissions to access the shared drive.
We were also able to reproduce the issue by: 

1. Go to https://myaccount.google.com/permissions
2. remove permissions for gdocwiki
3. sign out of gdocwiki
4. sign in to gdocwiki
5. and the error message appears.

The issue is caused by this: https://github.com/pingcap/gdocwiki/commit/08586d6ad2644c0633246a5a6a07db4f89b3a4d6
So the drive.file scope is too restrictive, we are proposing to use drive.readonly scope instead.

Have a great day!